### PR TITLE
fix: delimiter check cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [profile.release]
 lto = true
+codegen-units = 1
 
 [dev-dependencies]
 criterion = "0.4"

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use fzrs::*;
+use frizbee::*;
 use nucleo_matcher::{
     pattern::{Atom, AtomKind, CaseMatching, Normalization},
     Config, Matcher,
@@ -11,6 +11,8 @@ use std::io::{self, BufRead};
 use std::path::Path;
 
 fn get_data() -> Vec<String> {
+    // Download title.basics.tsv from https://datasets.imdbws.com
+    // and update this path to run benchmarks
     let path = Path::new("/home/saghen/downloads/title.basics.tsv");
     let file = File::open(path).unwrap();
     let reader = io::BufReader::new(file);

--- a/benches/smith_waterman.rs
+++ b/benches/smith_waterman.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use fzrs::simd::*;
+use frizbee::simd::*;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let needle = "banny";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/smith_waterman_macro/src/lib.rs
+++ b/smith_waterman_macro/src/lib.rs
@@ -39,13 +39,20 @@ pub fn generate_smith_waterman(input: TokenStream) -> TokenStream {
             let mut all_time_max_score = Simd::splat(0);
 
             // Delimiters
-            let mut is_delimiter_masks = [Mask::splat(false); #width];
-            let space_delimiter = Simd::splat(" ".bytes().next().unwrap() as #score_type);
-            let slash_delimiter = Simd::splat("/".bytes().next().unwrap() as #score_type);
-            let dot_delimiter = Simd::splat(".".bytes().next().unwrap() as #score_type);
-            let comma_delimiter = Simd::splat(",".bytes().next().unwrap() as #score_type);
-            let underscore_delimiter = Simd::splat("_".bytes().next().unwrap() as #score_type);
-            let dash_delimiter = Simd::splat("-".bytes().next().unwrap() as #score_type);
+            let space_delimiter = " ".bytes().next().unwrap() as #score_type;
+            let slash_delimiter = "/".bytes().next().unwrap() as #score_type;
+            let dot_delimiter = ".".bytes().next().unwrap() as #score_type;
+            let comma_delimiter = ",".bytes().next().unwrap() as #score_type;
+            let underscore_delimiter = "_".bytes().next().unwrap() as #score_type;
+            let dash_delimiter = "-".bytes().next().unwrap() as #score_type;
+            let mut delimiters_arr = [dash_delimiter; SIMD_WIDTH];
+            delimiters_arr[0] = space_delimiter;
+            delimiters_arr[1] = slash_delimiter;
+            delimiters_arr[2] = dot_delimiter;
+            delimiters_arr[3] = comma_delimiter;
+            delimiters_arr[4] = underscore_delimiter;
+            delimiters_arr[5] = dash_delimiter; // repeat for the rest of the array
+            let delimiters = Simd::from_array(delimiters_arr);
             let delimiter_bonus = Simd::splat(DELIMITER_BONUS as #score_type);
 
             // Capitalization
@@ -84,62 +91,57 @@ pub fn generate_smith_waterman(input: TokenStream) -> TokenStream {
                 let mut up_gap_penalty_mask = Mask::splat(true);
                 let mut curr_col_score_simds: [Simd<#score_type, SIMD_WIDTH>; #width_with_padding] = [Simd::splat(0); #width_with_padding];
 
+                let needle_char_is_delimiter = delimiters.simd_eq(needle_char).any();
+                let delimiter_bonus = if needle_char_is_delimiter {
+                    delimiter_bonus
+                } else {
+                    zero
+                };
+
                 for j in 1..=haystack_len {
+                    let prefix_mask = Mask::splat(j == 1);
                     // Load chunk and remove casing
-                    let cased_haystack_simd = Simd::<#score_type, SIMD_WIDTH>::from_slice(&haystack[j - 1]);
+                    let cased_haystack_simd = Simd::<#score_type, SIMD_WIDTH>::from_array(haystack[j - 1]);
                     let capital_mask = cased_haystack_simd
                         .simd_ge(capital_start)
                         .bitand(cased_haystack_simd.simd_le(capital_end));
                     let haystack_simd = cased_haystack_simd | capital_mask.select(to_lowercase_mask, zero);
 
                     // Give a bonus for prefix matches
-                    let match_score = Mask::splat(j == 1).select(prefix_match_score, match_score);
+                    let match_score = prefix_mask.select(prefix_match_score, match_score);
 
                     // Calculate diagonal (match/mismatch) scores
                     let diag = prev_col_score_simds[j - 1];
                     let match_mask = needle_char.simd_eq(haystack_simd);
                     let diag_score = match_mask.select(
                         diag + match_score
-                            + is_delimiter_masks[j - 1].select(delimiter_bonus, zero)
-                            + capital_mask.bitand(Mask::splat(j != 1)).select(capitalization_bonus, zero),
-                        diag.simd_gt(mismatch_score)
-                            .select(diag - mismatch_score, zero),
+                            + delimiter_bonus
+                            // XOR with prefix mask to ignore capitalization on the prefix
+                            + capital_mask.bitand(prefix_mask.not()).select(capitalization_bonus, zero),
+                        zero.simd_max(diag - mismatch_score),
                     );
 
                     // Load and calculate up scores
                     let up_gap_penalty = up_gap_penalty_mask.select(gap_open_penalty, gap_extend_penalty);
-                    let up_score = up_score_simd
-                        .simd_gt(up_gap_penalty)
-                        .select(up_score_simd - up_gap_penalty, zero);
+                    let up_score = zero.simd_max(up_score_simd - up_gap_penalty);
 
                     // Load and calculate left scores
                     let left = prev_col_score_simds[j];
                     let left_gap_penalty_mask = left_gap_penalty_masks[j - 1];
                     let left_gap_penalty =
                         left_gap_penalty_mask.select(gap_open_penalty, gap_extend_penalty);
-                    let left_score = left
-                        .simd_gt(left_gap_penalty)
-                        .select(left - left_gap_penalty, zero);
+                    let left_score = zero.simd_max(left - left_gap_penalty);
 
                     // Calculate maximum scores
+                    // Note up_score and left_score are >= 0, so max_score >= 0
                     let max_score = diag_score
                         .simd_max(up_score)
-                        .simd_max(left_score)
-                        .simd_max(zero);
+                        .simd_max(left_score);
 
                     // Update gap penalty mask
                     let diag_mask = max_score.simd_eq(diag_score);
                     up_gap_penalty_mask = max_score.simd_ne(up_score).bitor(diag_mask);
                     left_gap_penalty_masks[j - 1] = max_score.simd_ne(left_score).bitor(diag_mask);
-
-                    // Update delimiter mask
-                    is_delimiter_masks[j - 1] = space_delimiter
-                        .simd_eq(needle_char)
-                        .bitor(slash_delimiter.simd_eq(needle_char))
-                        .bitor(dot_delimiter.simd_eq(needle_char))
-                        .bitor(comma_delimiter.simd_eq(needle_char))
-                        .bitor(underscore_delimiter.simd_eq(needle_char))
-                        .bitor(dash_delimiter.simd_eq(needle_char));
 
                     // Store the scores for the next iterations
                     up_score_simd = max_score;
@@ -155,7 +157,9 @@ pub fn generate_smith_waterman(input: TokenStream) -> TokenStream {
             let mut max_scores_vec = [0; SIMD_WIDTH];
             for i in 0..SIMD_WIDTH {
                 max_scores_vec[i] = all_time_max_score[i] as u16;
-                if haystacks[i] == needle_str { max_scores_vec[i] += EXACT_MATCH_BONUS as u16; }
+                if haystacks[i] == needle_str {
+                    max_scores_vec[i] += EXACT_MATCH_BONUS as u16;
+                }
             }
             max_scores_vec
         }


### PR DESCRIPTION
I went through the code to understand the algorithm a bit better and was confused by the delimiter check. From my understanding this does what the delimiter check is supposed to do (but saving a small amount of work). 

While making this change, I also did some minor cleanup, where I changed some `select` calls to `simd_max` and tried to make the code in `smith_waterman_macro/src/lib.rs` and `src/simd.rs` look more similar. This is not really important, and I can remove some of these changes if you prefer. 

(I also added a toolchain file and set `codegen-unit=1` to try to improve performance, though it only gives a very minor boost overall - I see about 3-4% quicker benchmark times for `match_list` from this pull request compared to main and no real difference in `nucleo_match_list`.)