### PR TITLE
feat: drop useless select and simplify code

### DIFF
--- a/smith_waterman_macro/src/lib.rs
+++ b/smith_waterman_macro/src/lib.rs
@@ -119,24 +119,19 @@ pub fn generate_smith_waterman(input: TokenStream) -> TokenStream {
                             // XOR with prefix mask to ignore capitalization on the prefix
                             + capital_mask.bitand(prefix_mask.not()).select(capitalization_bonus, zero)
                             + matched_casing_mask.select(matching_casing_bonus, zero),
-                        diag.simd_gt(mismatch_score)
-                            .select(diag - mismatch_score, zero),
+                        diag.saturating_sub(mismatch_score),
                     );
 
                     // Load and calculate up scores
                     let up_gap_penalty = up_gap_penalty_mask.select(gap_open_penalty, gap_extend_penalty);
-                    let up_score = up_score_simd
-                        .simd_gt(up_gap_penalty)
-                        .select(up_score_simd - up_gap_penalty, zero);
+                    let up_score = up_score_simd.saturating_sub(up_gap_penalty);
 
                     // Load and calculate left scores
                     let left = prev_col_score_simds[j];
                     let left_gap_penalty_mask = left_gap_penalty_masks[j - 1];
                     let left_gap_penalty =
                         left_gap_penalty_mask.select(gap_open_penalty, gap_extend_penalty);
-                    let left_score = left
-                        .simd_gt(left_gap_penalty)
-                        .select(left - left_gap_penalty, zero);
+                    let left_score = left.saturating_sub(left_gap_penalty);
 
                     // Calculate maximum scores
                     let max_score = diag_score.simd_max(up_score).simd_max(left_score);


### PR DESCRIPTION
In the `a | b` code in the following, the select doesn't matter from what I can tell, and I figured out than rust Simd has `saturating_sub` which I think is cleaner than the compare select code. 

Note: Removing the need for `needle_cased_mask` and `capital_mask` here, means that one could choose to keep track of an exact equal (a ≠ A, but a = a, A = A) and an inexact equal (a = A) instead of the way code with capital letters currently work. 

Note 2: According to https://godbolt.org/z/8vb7vx39K the `saturating_sub` code generates the same assembly as the current code, so this is purely a matter of preference. (Whereas I think the code with select on `or` is truly not needed.)