### PR TITLE
feat: indicate exact matches

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -95,6 +95,8 @@ where
             matches.push(Match {
                 index_in_haystack: score_idx,
                 score: scores[idx],
+                // TODO: move match characteristics that give bonus to where bonus is calculated
+                exact: self.haystacks[idx] == needle,
                 indices: None,
             });
         }

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -75,7 +75,8 @@ where
             return;
         }
 
-        let (scores, score_matrix) = smith_waterman::<N, W, L>(needle, &self.haystacks);
+        let (scores, score_matrix, exact_matches) =
+            smith_waterman::<N, W, L>(needle, &self.haystacks);
 
         let typos = max_typos.map(|_| typos_from_score_matrix::<N, W, L>(&score_matrix));
         #[allow(clippy::needless_range_loop)]
@@ -95,8 +96,7 @@ where
             matches.push(Match {
                 index_in_haystack: score_idx,
                 score: scores[idx],
-                // TODO: move match characteristics that give bonus to where bonus is calculated
-                exact: self.haystacks[idx] == needle,
+                exact: exact_matches[idx],
                 indices: None,
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub fn match_list(needle: &str, haystacks: &[&str], opts: Options) -> Vec<Match>
             .map(|(i, _)| Match {
                 index_in_haystack: i,
                 score: 0,
+                exact: false,
                 indices: None,
             })
             .collect();
@@ -212,5 +213,33 @@ mod tests {
             },
         );
         assert_eq!(matches.len(), 3);
+    }
+
+    #[test]
+    fn test_exact_match() {
+        let needle = "deadbe";
+        let haystack = vec!["deadbeef", "deadbf", "deadbeefg", "deadbe"];
+
+        let matches = match_list(needle, &haystack, Options::default());
+
+        assert_eq!(matches.iter().filter(|m| m.exact).count(), 1);
+    }
+
+    #[test]
+    fn test_exact_matches() {
+        let needle = "deadbe";
+        let haystack = vec![
+            "deadbe",
+            "deadbeef",
+            "deadbe",
+            "deadbf",
+            "deadbe",
+            "deadbeefg",
+            "deadbe",
+        ];
+
+        let matches = match_list(needle, &haystack, Options::default());
+
+        assert_eq!(matches.iter().filter(|m| m.exact).count(), 4);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,7 @@ mod tests {
 
         let exact_matches = matches.iter().filter(|m| m.exact).collect::<Vec<&Match>>();
         assert_eq!(exact_matches.len(), 1);
+        assert_eq!(exact_matches[0].index_in_haystack, 3);
         for m in &exact_matches {
             assert_eq!(haystack[m.index_in_haystack], needle)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,11 @@ mod tests {
 
         let matches = match_list(needle, &haystack, Options::default());
 
-        assert_eq!(matches.iter().filter(|m| m.exact).count(), 1);
+        let exact_matches = matches.iter().filter(|m| m.exact).collect::<Vec<&Match>>();
+        assert_eq!(exact_matches.len(), 1);
+        for m in &exact_matches {
+            assert_eq!(haystack[m.index_in_haystack], needle)
+        }
     }
 
     #[test]
@@ -240,6 +244,10 @@ mod tests {
 
         let matches = match_list(needle, &haystack, Options::default());
 
-        assert_eq!(matches.iter().filter(|m| m.exact).count(), 4);
+        let exact_matches = matches.iter().filter(|m| m.exact).collect::<Vec<&Match>>();
+        assert_eq!(exact_matches.len(), 4);
+        for m in &exact_matches {
+            assert_eq!(haystack[m.index_in_haystack], needle)
+        }
     }
 }

--- a/src/match_.rs
+++ b/src/match_.rs
@@ -2,6 +2,7 @@
 pub struct Match {
     /** Index of the match in the original list of haystacks */
     pub index_in_haystack: usize,
-    pub score: u16,
     pub indices: Option<Vec<usize>>,
+    pub score: u16,
+    pub exact: bool,
 }

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -122,7 +122,7 @@ simd_num_impl!(u16, 1, 2, 4, 8, 16, 32);
 pub fn smith_waterman<N, const W: usize, const L: usize>(
     needle: &str,
     haystacks: &[&str; L],
-) -> ([u16; L], Vec<[Simd<N, L>; W]>)
+) -> ([u16; L], Vec<[Simd<N, L>; W]>, [bool; L])
 where
     N: SimdNum<L>,
     std::simd::LaneCount<L>: std::simd::SupportedLaneCount,
@@ -240,15 +240,20 @@ where
         }
     }
 
+    let mut exact_matches = [false; L];
+    for i in 0..L {
+        exact_matches[i] = haystacks[i] == needle_str;
+    }
+
     let mut max_scores_vec = [0u16; L];
     for i in 0..L {
         max_scores_vec[i] = all_time_max_score[i].into();
-        if haystacks[i] == needle_str {
+        if exact_matches[i] {
             max_scores_vec[i] += EXACT_MATCH_BONUS;
         }
     }
 
-    (max_scores_vec, score_matrix)
+    (max_scores_vec, score_matrix, exact_matches)
 }
 
 pub fn typos_from_score_matrix<N, const W: usize, const L: usize>(


### PR DESCRIPTION
This match characteristic is already checked in 'smith_waterman', but refactoring the function to retrieve it from there would likely require significant changes to a mission-critical section, where many optimizations focus on cache locality. Introducing a low-selectivity 8-bit boolean there might not be a wise decision. In the future, if we plan to add more characteristics to 'Match', it might make sense to use a bitmask in 'smith_waterman' instead and then convert it to normal boolean properties in 'Match'.