### PR TITLE
feat: runtime instruction detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,12 +218,22 @@ name = "frizbee"
 version = "0.3.0"
 dependencies = [
  "criterion",
+ "fuzzy-matcher",
  "iai-callgrind",
  "memchr",
  "nucleo-matcher",
  "rand",
  "rand_distr",
  "serde",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -611,6 +621,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ version = "0.3.0"
 edition = "2021"
 
 [profile.release]
-lto = "fat"
-opt-level = 3
+lto = true
 
 [dev-dependencies]
 criterion = "0.5"
+fuzzy-matcher = "0.3.7"
 iai-callgrind = "0.14.0"
 nucleo-matcher = "0.3.1"
 rand = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ version = "0.3.0"
 edition = "2021"
 
 [profile.release]
-lto = true
+lto = "fat"
+opt-level = 3
 
 [dev-dependencies]
 criterion = "0.5"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ nucleo                  time:   [301.74 µs 302.35 µs 303.10 µs]
 
 ## Algorithm
 
-The core of the algorithm is Smith-Waterman with affine gaps and inter-sequence many-to-one parallelism via SIMD ([ref](https://pmc.ncbi.nlm.nih.gov/articles/PMC8419822/#Sec13)). This is the basis of other popular fuzzy matching algorithms like FZF and Nucleo. The main properties of Smith-Waterman are:
+The core of the algorithm is Smith-Waterman with affine gaps and inter-sequence many-to-one parallelism via SIMD ([ref](https://pmc.ncbi.nlm.nih.gov/articles/PMC8419822/#Sec13)). Besides the parallelism, this is the basis of other popular fuzzy matching algorithms like FZF and Nucleo. The main properties of Smith-Waterman are:
 
 - Always finds the best alignment
 - Supports insertion, deletion and substitution

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Frizbee
 
-Frizbee is a SIMD fuzzy string matcher written in Rust. The core of the algorithm uses Smith-Waterman with affine gaps, similar to FZF, but with many of the scoring bonuses from FZY. In the included benchmark, with typo resistance disabled, it outperforms nucleo by ~2x (18.4us vs 35.8us). It matches against characters directly, ignoring unicode.
+Frizbee is a SIMD fuzzy string matcher written in Rust. The core of the algorithm uses Smith-Waterman with affine gaps, similar to FZF, but with many of the scoring bonuses from FZY. In the included benchmark, with typo resistance disabled, it outperforms nucleo by ~2.3x (130.70us vs 302.35us). It matches against bytes directly, ignoring unicode. Used by [blink.cmp](https://github.com/saghen/blink.cmp) and [blink.pick](https://github.com/saghen/blink.pick).
 
 ## Usage
 
@@ -15,7 +15,7 @@ let matches = match_list(needle, &haystacks, Options::default());
 
 ## Benchmarks
 
-Benchmarks were run on a Ryzen 7 3700X, with `-C target-cpu=native`. Results with different needles, partial match percentage, match percentage, median length, and number of samples are in the works. You may test these cases yourself via the included benchmarks.
+Benchmarks were run on a Ryzen 9950X3D. Results with different needles, partial match percentage, match percentage, median length, and number of samples are in the works. You may test these cases yourself via the included benchmarks.
 
 ```rust
 needle: "deadbe"
@@ -23,32 +23,34 @@ partial_match_percentage: 0.05
 match_percentage: 0.05
 median_length: 16
 std_dev_length: 4
-num_samples: 1000
+num_samples: 10000
 
 // Gets the scores for all of the items without any filtering
-frizbee                 time:   [54.892 µs 55.033 µs 55.209 µs]
+frizbee                 time:   [367.25 µs 368.44 µs 369.87 µs]
 // Performs the fastest prefilter since no typos are allowed
 // Matches the behavior of fzf/nucleo, set via `max_typos: Some(0)`
-frizbee_0_typos         time:   [18.283 µs 18.373 µs 18.482 µs]
+frizbee_0_typos         time:   [130.14 µs 130.70 µs 131.33 µs]
 // Performs a prefilter since a set number of typos are allowed,
 // set via `max_typos: Some(1)`
-frizbee_1_typos         time:   [27.963 µs 28.049 µs 28.143 µs]
-frizbee_2_typos         time:   [49.100 µs 49.177 µs 49.271 µs]
+frizbee_1_typos         time:   [280.29 µs 283.53 µs 286.87 µs]
+frizbee_2_typos         time:   [481.09 µs 482.44 µs 484.03 µs]
 
-nucleo                  time:   [35.686 µs 35.765 µs 35.848 µs]
+nucleo                  time:   [301.74 µs 302.35 µs 303.10 µs]
 ```
 
 ## Algorithm
 
 The core of the algorithm is Smith-Waterman with affine gaps and inter-sequence many-to-one parallelism via SIMD ([ref](https://pmc.ncbi.nlm.nih.gov/articles/PMC8419822/#Sec13)). This is the basis of other popular fuzzy matching algorithms like FZF and Nucleo. The main properties of Smith-Waterman are:
 
-- Always finds the best alignment 
+- Always finds the best alignment
 - Supports insertion, deletion and substitution
 - Does not support transposition (i.e. swapping two adjacent characters)
 
-Due to the inter-sequence parallelism, the algorithm performs best when all the haystacks are the same length (i.e. length 8) for the given SIMD width (i.e. 16 for 128 bit SIMD with u8 scores). The `match_list` function handles this by grouping the haystacks by length into "buckets" of various sizes (`4`, `8`, `12`, ...). Any haystack with length larger than the largest bucket will be discarded, for now.
+Due to the inter-sequence parallelism, the algorithm performs best when all the haystacks are the same length (i.e. length 8) for the given SIMD width (i.e. 16 for 256 bit SIMD with u16 scores). The `match_list` function handles this by grouping the haystacks by length into "buckets" of various sizes (`4`, `8`, `12`, ...). Any haystack with length larger than the largest bucket will be discarded, for now. 
 
-Nucleo and FZF use a prefiltering step that removes any haystacks that do not include all of the characters in the needle. Frizbee supports this but disables it by default to allow for typos. You may play with the `max_typos` property to control how many typos you allow.
+The SIMD width will be chosen at runtime based on available instruction set extensions. Currently, only x86_64's AVX2 (256-bit) and AVX512 (512-bit) will be detected at runtime, falling back to 128-bit SIMD if neither is available.
+
+Nucleo and FZF use a prefiltering step that removes any haystacks that do not include all of the characters in the needle. Frizbee supports this but disables it by default to allow for typos. You may control the maximum number of typos with the `max_typos` property.
 
 - `MATCH_SCORE`: Score for a match
 - `MISMATCH_PENALTY`: Penalty for a mismatch (substitution)
@@ -56,17 +58,19 @@ Nucleo and FZF use a prefiltering step that removes any haystacks that do not in
 - `GAP_EXTEND_PENALTY`: Penalty for extending a gap (deletion/insertion)
 - `PREFIX_BONUS`: Bonus for matching the first character of the haystack
 - `DELIMITER_BONUS`: Bonus for matching _after_ a delimiter character (e.g. "hw" on "hello_world", will give a bonus on "w")
+- `CAPITALIZATION_BONUS`: Bonus for matching a capital letter after a lowercase letter (e.g. "b" on "fooBar" will receive a bonus on "B")
 - `MATCHING_CASE_BONUS`: Bonus for matching the case of the needle (e.g. "WorLd" on "WoRld" will receive a bonus on "W", "o", "d")
 - `EXACT_MATCH_BONUS`: Bonus for matching the exact needle (e.g. "foo" on "foo" will receive the bonus)
 
 ## Ideas
 
-- [x] Incremental matching
-  - [ ] Prefiltering
-  - [ ] Exact match bonus
-- [ ] Runtime instruction selection (512-bit and 256-bit SIMD)
+- [x] Runtime instruction selection (512-bit and 256-bit SIMD)
 - [ ] Calculate alignment directions during matrix building
   - It should be possible to calculate the backtrace direction for the alignment phase while we're building the matrix, which could speed up typo calculation
 - [ ] Prefix matching
-- [ ] Drop u8 based scoring and double scoring to support longer fuzzy matches
+- [x] Drop u8 based scoring and double scoring to support longer fuzzy matches
   - Currently, alignment can be lost on longer matches causing us to mark them as having typos
+- [x] Incremental matching
+  - [ ] Runtime instruction selection (512-bit and 256-bit SIMD)
+  - [ ] Prefiltering
+  - [ ] Exact match bonus

--- a/benches/smith_waterman_iai.rs
+++ b/benches/smith_waterman_iai.rs
@@ -3,7 +3,7 @@ use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
 const NEEDLE: &str = "print";
-const HAYSTACK: [&str; 16] = [
+const HAYSTACK: [&str; 8] = [
     "XOpBuawtjG",
     "t6GuC",
     "rmLingPLt",
@@ -12,21 +12,13 @@ const HAYSTACK: [&str; 16] = [
     "BaMmlfqEW5xz",
     "V0884Xjfp",
     "YBeQ41Y",
-    "evXfkcR7iFz7nt",
-    "pYfrintXRv",
-    "print",
-    "9p7r6iOnt",
-    "TsNCxC05L4D4Y",
-    "vaAuDPiQDenHt",
-    "NQOK2K3cU",
-    "bnTt6e4i",
 ];
 
 #[library_benchmark]
 #[bench::print(NEEDLE, HAYSTACK)]
-fn bench_smith_waterman_simd_u8_16_16(needle: &str, haystack: [&str; 16]) -> [u16; 16] {
-    black_box(smith_waterman::<u8, 16, 16>(needle, &haystack).0)
+fn bench_smith_waterman_simd_u16_16_8(needle: &str, haystack: [&str; 8]) -> [u16; 8] {
+    black_box(smith_waterman::<u16, 16, 8>(needle, &haystack).0)
 }
 
-library_benchmark_group!(name = benches; benchmarks = bench_smith_waterman_simd_u8_16_16);
+library_benchmark_group!(name = benches; benchmarks = bench_smith_waterman_simd_u16_16_8);
 main!(library_benchmark_groups = benches);

--- a/src/const.rs
+++ b/src/const.rs
@@ -1,5 +1,5 @@
 pub const MATCH_SCORE: u16 = 12; // Score for a match
-pub const MISMATCH_PENALTY: u16 = 8; // Penalty for a mismatch (substitution)
+pub const MISMATCH_PENALTY: u16 = 4; // Penalty for a mismatch (substitution)
 pub const GAP_OPEN_PENALTY: u16 = 3; // Penalty for opening a gap (deletion/insertion)
 pub const GAP_EXTEND_PENALTY: u16 = 1; // Penalty for extending a gap (deletion/insertion)
 

--- a/src/const.rs
+++ b/src/const.rs
@@ -1,22 +1,10 @@
-// 128-bit SIMD with u16
-// NOTE: going above 128 bit results in much slower performance unless AVX2 is enabled at compile
-// time
-pub const SIMD_WIDTH: usize = 16;
+pub const MATCH_SCORE: u16 = 12; // Score for a match
+pub const MISMATCH_PENALTY: u16 = 8; // Penalty for a mismatch (substitution)
+pub const GAP_OPEN_PENALTY: u16 = 6; // Penalty for opening a gap (deletion/insertion)
+pub const GAP_EXTEND_PENALTY: u16 = 2; // Penalty for extending a gap (deletion/insertion)
 
-// NOTE: be very careful when changing these values since they affect what can fit in
-// the u8 scoring without overflowing
-
-pub const MATCH_SCORE: u16 = 6;
-pub const MISMATCH_PENALTY: u16 = 4; // -4
-pub const GAP_OPEN_PENALTY: u16 = 3; // -3
-pub const GAP_EXTEND_PENALTY: u16 = 1; // -1
-
-// bonus for matching the first character of the haystack
-pub const PREFIX_BONUS: u16 = 6;
-// bonus for matching character after a delimiter in the haystack (e.g. space, comma, underscore, slash, etc)
-pub const DELIMITER_BONUS: u16 = 4;
-// bonus for matching a letter that is capitalized on the haystack, if the character before it was lowercase
-pub const CAPITALIZATION_BONUS: u16 = 4;
-pub const MATCHING_CASE_BONUS: u16 = 2;
-// bonus for haystack == needle
-pub const EXACT_MATCH_BONUS: u16 = 4;
+pub const PREFIX_BONUS: u16 = 12; // Bonus for matching the first character of the haystack
+pub const DELIMITER_BONUS: u16 = 8; // Bonus for matching _after_ a delimiter character (e.g. "hw" on "hello_world", will give a bonus on "w")
+pub const CAPITALIZATION_BONUS: u16 = 8; // Bonus for matching a capital letter after a lowercase letter (e.g. "b" on "fooBar" will receive a bonus on "B")
+pub const MATCHING_CASE_BONUS: u16 = 4; // Bonus for matching the case of the needle (e.g. "WorLd" on "WoRld" will receive a bonus on "W", "o", "d")
+pub const EXACT_MATCH_BONUS: u16 = 8; // Bonus for matching the exact needle (e.g. "foo" on "foo" will receive the bonus)

--- a/src/const.rs
+++ b/src/const.rs
@@ -1,7 +1,7 @@
 pub const MATCH_SCORE: u16 = 12; // Score for a match
 pub const MISMATCH_PENALTY: u16 = 8; // Penalty for a mismatch (substitution)
-pub const GAP_OPEN_PENALTY: u16 = 6; // Penalty for opening a gap (deletion/insertion)
-pub const GAP_EXTEND_PENALTY: u16 = 2; // Penalty for extending a gap (deletion/insertion)
+pub const GAP_OPEN_PENALTY: u16 = 3; // Penalty for opening a gap (deletion/insertion)
+pub const GAP_EXTEND_PENALTY: u16 = 1; // Penalty for extending a gap (deletion/insertion)
 
 pub const PREFIX_BONUS: u16 = 12; // Bonus for matching the first character of the haystack
 pub const DELIMITER_BONUS: u16 = 8; // Bonus for matching _after_ a delimiter character (e.g. "hw" on "hello_world", will give a bonus on "w")

--- a/src/incremental/matcher.rs
+++ b/src/incremental/matcher.rs
@@ -17,12 +17,12 @@ impl IncrementalMatcher {
 
         let mut buckets: Vec<Box<dyn IncrementalBucketTrait>> = vec![];
 
-        let mut collection_size_4 = IncrementalBucketCollection::<'_, u8, 4, 16>::new();
-        let mut collection_size_8 = IncrementalBucketCollection::<'_, u8, 8, 16>::new();
-        let mut collection_size_12 = IncrementalBucketCollection::<'_, u8, 12, 16>::new();
-        let mut collection_size_16 = IncrementalBucketCollection::<'_, u8, 16, 16>::new();
-        let mut collection_size_20 = IncrementalBucketCollection::<'_, u8, 20, 16>::new();
-        let mut collection_size_24 = IncrementalBucketCollection::<'_, u8, 24, 16>::new();
+        let mut collection_size_4 = IncrementalBucketCollection::<'_, u16, 4, 8>::new();
+        let mut collection_size_8 = IncrementalBucketCollection::<'_, u16, 8, 8>::new();
+        let mut collection_size_12 = IncrementalBucketCollection::<'_, u16, 12, 8>::new();
+        let mut collection_size_16 = IncrementalBucketCollection::<'_, u16, 16, 8>::new();
+        let mut collection_size_20 = IncrementalBucketCollection::<'_, u16, 20, 8>::new();
+        let mut collection_size_24 = IncrementalBucketCollection::<'_, u16, 24, 8>::new();
         let mut collection_size_32 = IncrementalBucketCollection::<'_, u16, 32, 8>::new();
         let mut collection_size_48 = IncrementalBucketCollection::<'_, u16, 48, 8>::new();
         let mut collection_size_64 = IncrementalBucketCollection::<'_, u16, 64, 8>::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(portable_simd)]
+#![feature(avx512_target_feature)]
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/src/one_shot/matcher.rs
+++ b/src/one_shot/matcher.rs
@@ -1,4 +1,4 @@
-use super::bucket::{Bucket, FixedWidthBucket};
+use super::bucket::FixedWidthBucket;
 use crate::prefilter::bitmask::string_to_bitmask;
 use crate::{Match, Options};
 use std::cmp::Reverse;
@@ -29,28 +29,27 @@ pub fn match_list<S1: AsRef<str>, S2: AsRef<str>>(
 
     let needle_bitmask = string_to_bitmask(needle.as_bytes());
 
-    // Lazy bucket initialization - buckets are created only when needed
-    let mut bucket_size_4 = FixedWidthBucket::<u8, 4, 16>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_8 = FixedWidthBucket::<u8, 8, 16>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_12 = FixedWidthBucket::<u8, 12, 16>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_16 = FixedWidthBucket::<u8, 16, 16>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_20 = FixedWidthBucket::<u8, 20, 16>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_24 = FixedWidthBucket::<u8, 24, 16>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_32 = FixedWidthBucket::<u16, 32, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_48 = FixedWidthBucket::<u16, 48, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_64 = FixedWidthBucket::<u16, 64, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_96 = FixedWidthBucket::<u16, 96, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_128 = FixedWidthBucket::<u16, 128, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_160 = FixedWidthBucket::<u16, 160, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_192 = FixedWidthBucket::<u16, 192, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_224 = FixedWidthBucket::<u16, 224, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_256 = FixedWidthBucket::<u16, 256, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_384 = FixedWidthBucket::<u16, 384, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_512 = FixedWidthBucket::<u16, 512, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_768 = FixedWidthBucket::<u16, 768, 8>::new(needle, needle_bitmask, &opts);
-    let mut bucket_size_1024 = FixedWidthBucket::<u16, 1024, 8>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_4 = FixedWidthBucket::<4>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_8 = FixedWidthBucket::<8>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_12 = FixedWidthBucket::<12>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_16 = FixedWidthBucket::<16>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_20 = FixedWidthBucket::<20>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_24 = FixedWidthBucket::<24>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_32 = FixedWidthBucket::<32>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_48 = FixedWidthBucket::<48>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_64 = FixedWidthBucket::<64>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_96 = FixedWidthBucket::<96>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_128 = FixedWidthBucket::<128>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_160 = FixedWidthBucket::<160>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_192 = FixedWidthBucket::<192>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_224 = FixedWidthBucket::<224>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_256 = FixedWidthBucket::<256>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_384 = FixedWidthBucket::<384>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_512 = FixedWidthBucket::<512>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_768 = FixedWidthBucket::<768>::new(needle, needle_bitmask, &opts);
+    let mut bucket_size_1024 = FixedWidthBucket::<1024>::new(needle, needle_bitmask, &opts);
 
-    let mut matches = if opts.max_typos == None {
+    let mut matches = if opts.max_typos.is_none() {
         Vec::with_capacity(haystacks.len())
     } else {
         vec![]
@@ -185,3 +184,4 @@ mod tests {
         }
     }
 }
+

--- a/src/prefilter/bitmask.rs
+++ b/src/prefilter/bitmask.rs
@@ -12,6 +12,7 @@ pub fn string_to_bitmask(s: &[u8]) -> u64 {
 }
 
 const LANES: usize = 8;
+#[inline(always)]
 pub fn string_to_bitmask_simd(s: &[u8]) -> u64 {
     let mut mask: u64 = 0;
 

--- a/src/prefilter/memchr.rs
+++ b/src/prefilter/memchr.rs
@@ -1,11 +1,13 @@
 use memchr::{memchr, memchr2};
 
+#[inline(always)]
 pub fn prefilter(needle: &str, haystack: &str) -> bool {
     if needle.len() > haystack.len() {
         return false;
     }
     prefilter_ascii(needle.as_bytes(), haystack.as_bytes()).is_some()
 }
+#[inline(always)]
 pub fn prefilter_with_typo(needle: &str, haystack: &str) -> bool {
     if needle.len() > haystack.len() + 1 {
         return false;
@@ -15,6 +17,7 @@ pub fn prefilter_with_typo(needle: &str, haystack: &str) -> bool {
 
 /// Ripped directly from nucleo-matcher. It makes the algo much faster but disables resistance
 /// to typos
+#[inline(always)]
 fn prefilter_ascii(needle: &[u8], mut haystack: &[u8]) -> Option<()> {
     // If the first char is later than the haystack.len() - needle.len() + 1, then the
     // haystack is too short to contain the needle
@@ -28,6 +31,7 @@ fn prefilter_ascii(needle: &[u8], mut haystack: &[u8]) -> Option<()> {
 }
 
 /// Same as prefilter_ascii but allows for a single typo
+#[inline(always)]
 fn prefilter_ascii_with_typo(needle: &[u8], mut haystack: &[u8]) -> Option<()> {
     if needle.len() < 2 {
         return Some(());

--- a/src/smith_waterman/simd/algorithm.rs
+++ b/src/smith_waterman/simd/algorithm.rs
@@ -154,7 +154,7 @@ mod tests {
     const CHAR_SCORE: u16 = MATCH_SCORE + MATCHING_CASE_BONUS;
 
     fn get_score(needle: &str, haystack: &str) -> u16 {
-        smith_waterman::<u8, 16, 1>(needle, &[haystack; 1]).0[0]
+        smith_waterman::<u16, 16, 1>(needle, &[haystack; 1]).0[0]
     }
 
     #[test]

--- a/src/smith_waterman/simd/indices.rs
+++ b/src/smith_waterman/simd/indices.rs
@@ -115,7 +115,7 @@ mod tests {
 
     fn run_single_indices(needle: &str, haystack: &str) -> Vec<usize> {
         let haystacks = [haystack; 1];
-        let (_, score_matrices, _) = smith_waterman::<u8, 16, 1>(needle, &haystacks);
+        let (_, score_matrices, _) = smith_waterman::<u16, 16, 1>(needle, &haystacks);
         let indices = char_indices_from_scores(&score_matrices);
         indices[0].clone()
     }
@@ -142,7 +142,7 @@ mod tests {
             "toolbar",
         ];
 
-        let (_, score_matrices, _) = smith_waterman::<u8, 16, 16>(needle, &haystacks);
+        let (_, score_matrices, _) = smith_waterman::<u16, 16, 16>(needle, &haystacks);
         let indices = char_indices_from_scores(&score_matrices);
         for indices in indices.into_iter() {
             assert_eq!(indices, [0])

--- a/src/smith_waterman/simd/types.rs
+++ b/src/smith_waterman/simd/types.rs
@@ -118,7 +118,6 @@ macro_rules! simd_num_impl {
         )+
     };
 }
-simd_num_impl!(u8, 1, 2, 4, 8, 16, 32, 64);
 simd_num_impl!(u16, 1, 2, 4, 8, 16, 32);
 
 #[inline(always)]

--- a/src/smith_waterman/simd/typos.rs
+++ b/src/smith_waterman/simd/typos.rs
@@ -82,7 +82,7 @@ mod tests {
     use crate::smith_waterman::simd::smith_waterman;
 
     fn get_typos(needle: &str, haystack: &str) -> u16 {
-        typos_from_score_matrix(&smith_waterman::<u8, 4, 1>(needle, &[haystack; 1]).1)[0]
+        typos_from_score_matrix(&smith_waterman::<u16, 4, 1>(needle, &[haystack; 1]).1)[0]
     }
 
     #[test]


### PR DESCRIPTION
Adds runtime detection of AVX2 and AVX512 instructions for a 2x perf increase in the AVX512 case versus 128bit. Removes the `u8` path though, so its the same speed in those cases.

Also fixes an issue with `_A` receiving both the capital and delimiter bonus matching against `a`