### PR TITLE
feat: stop calculating typos after reaching max typos

### DIFF
--- a/src/incremental/bucket.rs
+++ b/src/incremental/bucket.rs
@@ -117,7 +117,8 @@ where
         });
 
         // TODO: typos
-        let typos = max_typos.map(|_| typos_from_score_matrix::<N, W, L>(&self.score_matrix));
+        let typos = max_typos
+            .map(|max_typos| typos_from_score_matrix::<N, W, L>(&self.score_matrix, max_typos));
 
         #[allow(clippy::needless_range_loop)]
         for idx in 0..self.length {

--- a/src/one_shot/bucket.rs
+++ b/src/one_shot/bucket.rs
@@ -129,7 +129,7 @@ impl<'a, const W: usize> FixedWidthBucket<'a, W> {
 
         let typos = self
             .max_typos
-            .map(|_| typos_from_score_matrix::<N, W, L>(&score_matrix));
+            .map(|max_typos| typos_from_score_matrix::<N, W, L>(&score_matrix, max_typos));
 
         let mut matched_indices = self
             .matched_indices

--- a/src/smith_waterman/simd/typos.rs
+++ b/src/smith_waterman/simd/typos.rs
@@ -6,6 +6,7 @@ use super::{SimdMask, SimdNum, SimdVec};
 #[inline]
 pub fn typos_from_score_matrix<N, const W: usize, const L: usize>(
     score_matrix: &[[Simd<N, L>; W]],
+    max_typos: u16,
 ) -> [u16; L]
 where
     N: SimdNum<L>,
@@ -34,6 +35,10 @@ where
 
         // NOTE: row_idx = 0 or col_idx = 0 will always have a score of 0
         while col_idx > 0 {
+            if typo_count[idx] > max_typos {
+                break;
+            }
+
             // Must be moving left
             if row_idx == 0 {
                 typo_count[idx] += 1;
@@ -82,7 +87,10 @@ mod tests {
     use crate::smith_waterman::simd::smith_waterman;
 
     fn get_typos(needle: &str, haystack: &str) -> u16 {
-        typos_from_score_matrix(&smith_waterman::<u16, 4, 1>(needle, &[haystack; 1], None).1)[0]
+        typos_from_score_matrix(
+            &smith_waterman::<u16, 4, 1>(needle, &[haystack; 1], Some(1)).1,
+            100,
+        )[0]
     }
 
     #[test]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d1b565bc-dfd2-426f-94fb-bc7a8d0890b7)

Previously, we were calculating the total number of typos, regardless of what our limit was for filtering the item out. Now, we stop calculating the typos for an item if it reaches the maximum. Note that the speed up won't apply to max_typos == 0 | 1 when the haystack_len > 24