### PR TITLE
feat!: Use ref borrowing for config

### DIFF
--- a/benches/match_list/mod.rs
+++ b/benches/match_list/mod.rs
@@ -95,7 +95,7 @@ fn match_list(needle: &str, haystack: &[&str], max_typos: Option<u16>) -> Vec<fr
     frizbee::match_list(
         black_box(needle),
         black_box(haystack),
-        black_box(frizbee::Config {
+        black_box(&frizbee::Config {
             max_typos,
             ..Default::default()
         }),
@@ -111,7 +111,7 @@ fn match_list_parallel(
     frizbee::match_list_parallel(
         black_box(needle),
         black_box(haystack),
-        frizbee::Config {
+        &frizbee::Config {
             max_typos,
             ..Default::default()
         },

--- a/benches/prefilter.rs
+++ b/benches/prefilter.rs
@@ -52,6 +52,7 @@ fn run_prefilter_bench<const W: usize>(c: &mut criterion::Criterion, needle: &st
     group.bench_function("simd/insensitive", |b| {
         b.iter(|| simd::match_haystack_insensitive(needle_cased, haystack))
     });
+    #[cfg(target_arch = "x86_64")]
     group.bench_function("x86_64/insensitive", |b| {
         b.iter(|| unsafe {
             frizbee::prefilter::x86_64::match_haystack_insensitive(needle_cased, haystack)

--- a/src/incremental/matcher.rs
+++ b/src/incremental/matcher.rs
@@ -86,7 +86,7 @@ impl IncrementalMatcher {
         }
     }
 
-    pub fn match_needle<S: AsRef<str>>(&mut self, needle: S, config: Config) -> Vec<Match> {
+    pub fn match_needle<S: AsRef<str>>(&mut self, needle: S, config: &Config) -> Vec<Match> {
         let needle = needle.as_ref();
         if needle.is_empty() {
             todo!();
@@ -107,7 +107,7 @@ impl IncrementalMatcher {
             })
             .unwrap_or(0);
 
-        self.process(common_prefix_len, needle, &mut matches, config.clone());
+        self.process(common_prefix_len, needle, &mut matches, &config);
         self.needle = Some(needle.to_owned());
 
         if config.sort {
@@ -122,7 +122,7 @@ impl IncrementalMatcher {
         prefix_to_keep: usize,
         needle: &str,
         matches: &mut Vec<Match>,
-        config: Config,
+        config: &Config,
     ) {
         let needle = &needle.as_bytes()[prefix_to_keep..];
 
@@ -147,7 +147,7 @@ mod tests {
 
     fn get_score(needle: &str, haystack: &str) -> u16 {
         let mut matcher = IncrementalMatcher::new(&[haystack]);
-        matcher.match_needle(needle, Config::default())[0].score
+        matcher.match_needle(needle, &Config::default())[0].score
     }
 
     #[test]

--- a/src/one_shot/indices.rs
+++ b/src/one_shot/indices.rs
@@ -13,7 +13,7 @@ use crate::{Config, MatchIndices};
 pub fn match_indices<S1: AsRef<str>, S2: AsRef<str>>(
     needle: S1,
     haystack: S2,
-    config: Config,
+    config: &Config,
 ) -> Option<MatchIndices> {
     let needle = needle.as_ref();
     let haystack = haystack.as_ref();

--- a/src/one_shot/matcher.rs
+++ b/src/one_shot/matcher.rs
@@ -14,7 +14,7 @@ use crate::{Config, Match};
 pub fn match_list<S1: AsRef<str>, S2: AsRef<str>>(
     needle: S1,
     haystacks: &[S2],
-    config: Config,
+    config: &Config,
 ) -> Vec<Match> {
     let mut matches = if config.max_typos.is_none() {
         Vec::with_capacity(haystacks.len())
@@ -22,7 +22,7 @@ pub fn match_list<S1: AsRef<str>, S2: AsRef<str>>(
         vec![]
     };
 
-    match_list_impl(needle, haystacks, 0, config.clone(), &mut matches);
+    match_list_impl(needle, haystacks, 0, config, &mut matches);
 
     if config.sort {
         #[cfg(feature = "parallel_sort")]
@@ -41,7 +41,7 @@ pub(crate) fn match_list_impl<S1: AsRef<str>, S2: AsRef<str>, M: Appendable<Matc
     needle: S1,
     haystacks: &[S2],
     index_offset: u32,
-    config: Config,
+    config: &Config,
     matches: &mut M,
 ) {
     assert!(
@@ -177,7 +177,7 @@ mod tests {
             max_typos: None,
             ..Config::default()
         };
-        let matches = match_list(needle, &haystack, config);
+        let matches = match_list(needle, &haystack, &config);
 
         assert_eq!(matches.len(), 4);
         assert_eq!(matches[0].index, 3);
@@ -194,7 +194,7 @@ mod tests {
         let matches = match_list(
             needle,
             &haystack,
-            Config {
+            &Config {
                 max_typos: Some(0),
                 ..Config::default()
             },
@@ -207,7 +207,7 @@ mod tests {
         let needle = "deadbe";
         let haystack = vec!["deadbeef", "deadbf", "deadbeefg", "deadbe"];
 
-        let matches = match_list(needle, &haystack, Config::default());
+        let matches = match_list(needle, &haystack, &Config::default());
 
         let exact_matches = matches.iter().filter(|m| m.exact).collect::<Vec<&Match>>();
         assert_eq!(exact_matches.len(), 1);
@@ -230,7 +230,7 @@ mod tests {
             "deadbe",
         ];
 
-        let matches = match_list(needle, &haystack, Config::default());
+        let matches = match_list(needle, &haystack, &Config::default());
 
         let exact_matches = matches.iter().filter(|m| m.exact).collect::<Vec<&Match>>();
         assert_eq!(exact_matches.len(), 4);

--- a/src/one_shot/parallel/mod.rs
+++ b/src/one_shot/parallel/mod.rs
@@ -19,7 +19,7 @@ use threaded_vec::ThreadedVec;
 pub fn match_list_parallel<S1: AsRef<str>, S2: AsRef<str> + Sync + Send>(
     needle: S1,
     haystacks: &[S2],
-    config: Config,
+    config: &Config,
     max_threads: usize,
 ) -> Vec<Match> {
     let thread_count = choose_thread_count(haystacks.len(), config.max_typos).clamp(1, max_threads);
@@ -28,8 +28,8 @@ pub fn match_list_parallel<S1: AsRef<str>, S2: AsRef<str> + Sync + Send>(
     }
 
     let mut matches = match config.max_typos {
-        None => match_list_parallel_fixed(needle, haystacks, config.clone(), thread_count),
-        _ => match_list_parallel_expandable(needle, haystacks, config.clone(), thread_count),
+        None => match_list_parallel_fixed(needle, haystacks, config, thread_count),
+        _ => match_list_parallel_expandable(needle, haystacks, config, thread_count),
     };
 
     if config.sort {
@@ -50,7 +50,7 @@ pub fn match_list_parallel<S1: AsRef<str>, S2: AsRef<str> + Sync + Send>(
 fn match_list_parallel_fixed<S1: AsRef<str>, S2: AsRef<str> + Sync + Send>(
     needle: S1,
     haystacks: &[S2],
-    config: Config,
+    config: &Config,
     thread_count: usize,
 ) -> Vec<Match> {
     assert!(config.max_typos.is_none(), "max_typos must be None");
@@ -79,7 +79,7 @@ fn match_list_parallel_fixed<S1: AsRef<str>, S2: AsRef<str> + Sync + Send>(
                     needle,
                     haystacks,
                     (thread_idx * items_per_thread) as u32,
-                    opts,
+                    &opts,
                     &mut thread_slice,
                 )
             });
@@ -97,7 +97,7 @@ fn match_list_parallel_fixed<S1: AsRef<str>, S2: AsRef<str> + Sync + Send>(
 fn match_list_parallel_expandable<S1: AsRef<str>, S2: AsRef<str> + Sync + Send>(
     needle: S1,
     haystacks: &[S2],
-    config: Config,
+    config: &Config,
     thread_count: usize,
 ) -> Vec<Match> {
     assert!(config.max_typos.is_some(), "max_typos must be Some");
@@ -118,7 +118,7 @@ fn match_list_parallel_expandable<S1: AsRef<str>, S2: AsRef<str> + Sync + Send>(
                     needle,
                     haystacks,
                     (thread_idx * items_per_thread) as u32,
-                    opts,
+                    &opts,
                     &mut matches,
                 )
             });


### PR DESCRIPTION
The API in the latest version changed which requires cloning config because it takes the owned version which makes no sense. Let's just use borrowing and avoid unnecessay cloning. 

The other questoin about the string for delimiters: does the API need it to be a string? Should it be configurable at compile time. E.g. to take the const N: usize generic and have the stored as [char; N]? Or it is also possible to use SmallVec to make this struct stack allocated again