### PR TITLE
Add cdylib support for FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ harness = false
 
 [lib]
 bench = false
+name = "frizbee"
+crate-type=["cdylib", "rlib"]
 
 # [[bench]]
 # name = "smith_waterman_iai"


### PR DESCRIPTION
This PR adds `cdylib` to the crate-type configuration, enabling the library to be built as a dynamic library (`.so`/`.dylib`) in addition to the existing static library (`.rlib`).