### PR TITLE
chore: Fix the nightly version in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-02-10"


### PR DESCRIPTION
When I maintain my fork it is hard to pull becuase it is unclear which version was used to test and build the frizbee. Sometimes new features are used or some version are just unstable.

I propose to fix the nightly channel in the rust toolchain toml this and update it accordingly. This will make it easier to maintain libraries and forks