### PR TITLE
feat: Make config copyable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-02-10"

--- a/src/incremental/bucket.rs
+++ b/src/incremental/bucket.rs
@@ -97,10 +97,10 @@ impl<const W: usize, const L: usize> IncrementalBucketTrait for IncrementalBucke
 
         #[allow(clippy::needless_range_loop)]
         for idx in 0..self.length {
-            if let Some(max_typos) = max_typos {
-                if typos.is_some_and(|typos| typos[idx] > max_typos) {
-                    continue;
-                }
+            if let Some(max_typos) = max_typos
+                && typos.is_some_and(|typos| typos[idx] > max_typos)
+            {
+                continue;
             }
 
             let score_idx = self.idxs[idx];

--- a/src/incremental/matcher.rs
+++ b/src/incremental/matcher.rs
@@ -107,7 +107,7 @@ impl IncrementalMatcher {
             })
             .unwrap_or(0);
 
-        self.process(common_prefix_len, needle, &mut matches, &config);
+        self.process(common_prefix_len, needle, &mut matches, config);
         self.needle = Some(needle.to_owned());
 
         if config.sort {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub struct MatchIndices {
     pub exact: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Config {
     /// May perform prefiltering, depending on haystack length and max number of typos,
@@ -87,7 +87,7 @@ impl Default for Config {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Scoring {
     /// Score for a matching character between needle and haystack
@@ -113,7 +113,7 @@ pub struct Scoring {
     pub exact_match_bonus: u16,
 
     /// List of characters which are considered delimiters
-    pub delimiters: String,
+    pub delimiters: &'static str,
     /// Bonus for matching _after_ a delimiter character (e.g. "hw" on "hello_world",
     /// will give a bonus on "w") if "_" is included in the delimiters string
     pub delimiter_bonus: u16,
@@ -133,7 +133,7 @@ impl Default for Scoring {
             matching_case_bonus: MATCHING_CASE_BONUS,
             exact_match_bonus: EXACT_MATCH_BONUS,
 
-            delimiters: " /.,_-:".to_string(),
+            delimiters: " /.,_-:",
             delimiter_bonus: DELIMITER_BONUS,
         }
     }

--- a/src/one_shot/bucket.rs
+++ b/src/one_shot/bucket.rs
@@ -41,7 +41,7 @@ impl<'a, const W: usize, M: Appendable<Match>> FixedWidthBucket<'a, W, M> {
             idxs: [0; 32],
 
             max_typos: config.max_typos,
-            scoring: config.scoring.clone(),
+            scoring: config.scoring,
 
             _phantom: PhantomData,
         }

--- a/src/one_shot/matcher.rs
+++ b/src/one_shot/matcher.rs
@@ -1,5 +1,5 @@
-use super::Appendable;
 use super::bucket::FixedWidthBucket;
+use super::Appendable;
 
 use crate::one_shot::match_too_large;
 use crate::prefilter::Prefilter;
@@ -63,23 +63,23 @@ pub(crate) fn match_list_impl<S1: AsRef<str>, S2: AsRef<str>, M: Appendable<Matc
 
     let prefilter = Prefilter::new(needle, config.max_typos.unwrap_or(0));
 
-    let mut bucket_size_4 = FixedWidthBucket::<4, M>::new(needle, &config);
-    let mut bucket_size_8 = FixedWidthBucket::<8, M>::new(needle, &config);
-    let mut bucket_size_12 = FixedWidthBucket::<12, M>::new(needle, &config);
-    let mut bucket_size_16 = FixedWidthBucket::<16, M>::new(needle, &config);
-    let mut bucket_size_20 = FixedWidthBucket::<20, M>::new(needle, &config);
-    let mut bucket_size_24 = FixedWidthBucket::<24, M>::new(needle, &config);
-    let mut bucket_size_32 = FixedWidthBucket::<32, M>::new(needle, &config);
-    let mut bucket_size_48 = FixedWidthBucket::<48, M>::new(needle, &config);
-    let mut bucket_size_64 = FixedWidthBucket::<64, M>::new(needle, &config);
-    let mut bucket_size_96 = FixedWidthBucket::<96, M>::new(needle, &config);
-    let mut bucket_size_128 = FixedWidthBucket::<128, M>::new(needle, &config);
-    let mut bucket_size_160 = FixedWidthBucket::<160, M>::new(needle, &config);
-    let mut bucket_size_192 = FixedWidthBucket::<192, M>::new(needle, &config);
-    let mut bucket_size_224 = FixedWidthBucket::<224, M>::new(needle, &config);
-    let mut bucket_size_256 = FixedWidthBucket::<256, M>::new(needle, &config);
-    let mut bucket_size_384 = FixedWidthBucket::<384, M>::new(needle, &config);
-    let mut bucket_size_512 = FixedWidthBucket::<512, M>::new(needle, &config);
+    let mut bucket_size_4 = FixedWidthBucket::<4, M>::new(needle, config);
+    let mut bucket_size_8 = FixedWidthBucket::<8, M>::new(needle, config);
+    let mut bucket_size_12 = FixedWidthBucket::<12, M>::new(needle, config);
+    let mut bucket_size_16 = FixedWidthBucket::<16, M>::new(needle, config);
+    let mut bucket_size_20 = FixedWidthBucket::<20, M>::new(needle, config);
+    let mut bucket_size_24 = FixedWidthBucket::<24, M>::new(needle, config);
+    let mut bucket_size_32 = FixedWidthBucket::<32, M>::new(needle, config);
+    let mut bucket_size_48 = FixedWidthBucket::<48, M>::new(needle, config);
+    let mut bucket_size_64 = FixedWidthBucket::<64, M>::new(needle, config);
+    let mut bucket_size_96 = FixedWidthBucket::<96, M>::new(needle, config);
+    let mut bucket_size_128 = FixedWidthBucket::<128, M>::new(needle, config);
+    let mut bucket_size_160 = FixedWidthBucket::<160, M>::new(needle, config);
+    let mut bucket_size_192 = FixedWidthBucket::<192, M>::new(needle, config);
+    let mut bucket_size_224 = FixedWidthBucket::<224, M>::new(needle, config);
+    let mut bucket_size_256 = FixedWidthBucket::<256, M>::new(needle, config);
+    let mut bucket_size_384 = FixedWidthBucket::<384, M>::new(needle, config);
+    let mut bucket_size_512 = FixedWidthBucket::<512, M>::new(needle, config);
 
     // If max_typos is set, we can ignore any haystacks that are shorter than the needle
     // minus the max typos, since it's impossible for them to match

--- a/src/one_shot/parallel/mod.rs
+++ b/src/one_shot/parallel/mod.rs
@@ -73,7 +73,7 @@ fn match_list_parallel_fixed<S1: AsRef<str>, S2: AsRef<str> + Sync + Send>(
 
             let needle = needle.as_ref().to_owned();
             let mut thread_slice = ThreadSlice::new(matches_slice);
-            let opts = config.clone();
+            let opts = *config;
             s.spawn(move || {
                 match_list_impl(
                     needle,
@@ -112,7 +112,7 @@ fn match_list_parallel_expandable<S1: AsRef<str>, S2: AsRef<str> + Sync + Send>(
 
             let needle = needle.as_ref().to_owned();
             let mut matches = matches.clone();
-            let opts = config.clone();
+            let opts = *config;
             s.spawn(move || {
                 match_list_impl(
                     needle,


### PR DESCRIPTION
This is literally fixing the pain point of the public API and improves the usage of internal tooling (less explicit dereferences) even though the performance impact is minimal this is very annoying that you need to copy that is anyway stack allocated by the compiler. 

Like for example in a loop I can not simply move the frizbee config in the block and modify the options for max typos for example I have to deal with the ownership which sometimes becomes tricky