### PR TITLE
feat: Leverage config in match_indicies

### DIFF
--- a/src/one_shot/indices.rs
+++ b/src/one_shot/indices.rs
@@ -32,7 +32,7 @@ pub fn match_indices<S1: AsRef<str>, S2: AsRef<str>>(
     }
 
     // Get score matrix
-    let (score, score_matrix, exact) = smith_waterman(needle, haystack);
+    let (score, score_matrix, exact) = smith_waterman(needle, haystack, &config.scoring);
     let score_matrix_ref = score_matrix
         .iter()
         .map(|v| v.as_slice())

--- a/src/smith_waterman/reference/indices.rs
+++ b/src/smith_waterman/reference/indices.rs
@@ -82,9 +82,10 @@ pub fn char_indices_from_score_matrix(score_matrix: &[&[u16]]) -> Vec<usize> {
 mod tests {
     use super::super::smith_waterman;
     use super::char_indices_from_score_matrix;
+    use crate::Scoring;
 
     fn get_indices(needle: &str, haystack: &str) -> Vec<usize> {
-        let (_, score_matrix, _) = smith_waterman(needle, haystack);
+        let (_, score_matrix, _) = smith_waterman(needle, haystack, &Scoring::default());
         let score_matrix_ref = score_matrix
             .iter()
             .map(|v| v.as_slice())

--- a/src/smith_waterman/reference/typos.rs
+++ b/src/smith_waterman/reference/typos.rs
@@ -65,9 +65,10 @@ pub fn typos_from_score_matrix(score_matrix: &[&[u16]]) -> u16 {
 mod tests {
     use super::super::smith_waterman;
     use super::typos_from_score_matrix;
+    use crate::Scoring;
 
     fn get_typos(needle: &str, haystack: &str) -> u16 {
-        let (_, score_matrix, _) = smith_waterman(needle, haystack);
+        let (_, score_matrix, _) = smith_waterman(needle, haystack, &Scoring::default());
         let score_matrix_ref = score_matrix
             .iter()
             .map(|v| v.as_slice())


### PR DESCRIPTION
The smith_waterman for some reason is using hardcoded values which is breaking the consistency if scoring is eliminating ceratin value.

This patch fixes it and allows to use the actual config from the parameters