### PR TITLE
feat: incremental matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ harness = false
 name = "sort"
 harness = false
 
+[[bench]]
+name = "incremental"
+harness = false
+
 [lib]
 bench = false
 

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -1,9 +1,3 @@
-//! Benchmark: IncrementalMatcher vs one-shot match_list
-//!
-//! Measures the real-world benefit of incremental matching when a user types
-//! a query character by character. Tests multiple query patterns, dataset sizes,
-//! and shows per-step breakdowns where the narrowing effect is visible.
-
 use std::hint::black_box;
 use std::time::{Duration, Instant};
 
@@ -12,140 +6,76 @@ use rand_distr::{Distribution, Normal};
 
 use frizbee::{Config, IncrementalMatcher, match_list};
 
+const ITERS: u32 = 20;
+
 fn main() {
     let config = Config::default();
 
-    // ============================================================
-    // 1. File-path dataset (realistic fuzzy finder workload)
-    // ============================================================
-    println!("=== File-Path Dataset (simulated project tree) ===\n");
-
     for &count in &[50_000usize, 200_000, 500_000] {
-        let haystacks = generate_file_paths(count, 42);
+        let haystacks = gen_paths(count, 42);
         let refs: Vec<&str> = haystacks.iter().map(|s| s.as_str()).collect();
-
-        // Multiple query patterns that resemble real fuzzy finder usage
-        let queries: &[(&str, &[&str])] = &[
-            // Searching for a file by abbreviation (high selectivity)
-            ("mch", &["m", "mc", "mch"]),
-            // Typing a common path segment (low selectivity early, high later)
-            ("src/comp", &["s", "sr", "src", "src/", "src/c", "src/co", "src/com", "src/comp"]),
-            // CamelCase search for a component name
-            ("BtLs", &["B", "Bt", "BtL", "BtLs"]),
-        ];
 
         println!("--- {} haystacks ---\n", count);
 
-        for &(label, steps) in queries {
-            bench_query(&refs, steps, label, &config);
-        }
-    }
-
-    // ============================================================
-    // 2. Selectivity comparison
-    // ============================================================
-    println!("\n=== Selectivity Impact ===\n");
-    println!("Shows how incremental speedup varies with match ratio.\n");
-
-    let haystacks = generate_file_paths(200_000, 42);
-    let refs: Vec<&str> = haystacks.iter().map(|s| s.as_str()).collect();
-
-    // Pairs: (query, description) — ordered by expected selectivity (high match% → low match%)
-    let selectivity_queries: &[(&[&str], &str)] = &[
-        (&["s", "sr", "src"], "common prefix (high match%)"),
-        (&["c", "co", "com", "comp"], "medium selectivity"),
-        (&["B", "Bt", "BtL", "BtLs"], "CamelCase (low match%)"),
-        (&["z", "zx", "zxq"], "rare chars (very low match%)"),
-    ];
-
-    println!(
-        "  {:30} {:>10} {:>10} {:>7} {:>10}",
-        "Query", "One-shot", "Incremental", "Speedup", "Final matches"
-    );
-    println!("  {}", "-".repeat(71));
-
-    for &(steps, desc) in selectivity_queries {
-        let final_needle = steps.last().unwrap();
-        let final_matches = match_list(final_needle, &refs, &config).len();
-
-        let iters = 20u32;
-        let one_shot = time_avg(iters, || {
-            for &n in steps {
-                black_box(match_list(n, black_box(&refs), &config));
-            }
-        });
-        let incr = time_avg(iters, || {
-            let mut m = IncrementalMatcher::new(&config);
-            for &n in steps {
-                black_box(m.match_list(n, black_box(&refs)));
-            }
-        });
-
-        println!(
-            "  {:30} {:>10.2?} {:>10.2?} {:>6.2}x {:>10}",
-            format!("{:?} ({})", steps.last().unwrap(), desc),
-            one_shot,
-            incr,
-            one_shot.as_nanos() as f64 / incr.as_nanos() as f64,
-            final_matches,
+        bench_query(&refs, &["m", "mc", "mch"], &config);
+        bench_query(
+            &refs,
+            &[
+                "s", "sr", "src", "src/", "src/c", "src/co", "src/com", "src/comp",
+            ],
+            &config,
         );
+        bench_query(&refs, &["B", "Bt", "BtL", "BtLs"], &config);
+        bench_query(&refs, &["z", "zx", "zxq"], &config);
     }
 }
 
-/// Benchmark a single query pattern: overall + per-step breakdown
-fn bench_query(haystacks: &[&str], steps: &[&str], label: &str, config: &Config) {
-    let iters = 20u32;
-
-    // Overall timing
-    let one_shot_total = time_avg(iters, || {
+fn bench_query(haystacks: &[&str], steps: &[&str], config: &Config) {
+    let one_shot_total = time_avg(ITERS, || {
         for &n in steps {
             black_box(match_list(n, black_box(haystacks), config));
         }
     });
-    let incr_total = time_avg(iters, || {
+    let incr_total = time_avg(ITERS, || {
         let mut m = IncrementalMatcher::new(config);
         for &n in steps {
             black_box(m.match_list(n, black_box(haystacks)));
         }
     });
 
-    println!("  Query {:?} ({} steps)", label, steps.len());
+    let label = steps.last().unwrap();
     println!(
-        "    Overall:  one-shot {:>9.2?}  incremental {:>9.2?}  ({:.2}x)",
+        "  {:?}: one-shot {:>9.2?}  incr {:>9.2?}  ({:.2}x)",
+        label,
         one_shot_total,
         incr_total,
         one_shot_total.as_nanos() as f64 / incr_total.as_nanos() as f64,
     );
 
-    // Per-step breakdown
     println!(
         "    {:>10} {:>8} {:>10} {:>10} {:>7}",
-        "Needle", "Matches", "One-shot", "Incremental", "Speedup"
+        "needle", "matches", "one-shot", "incr", "speedup"
     );
 
-    for (step_idx, &needle) in steps.iter().enumerate() {
-        let matches = match_list(needle, haystacks, config).len();
+    for (i, &needle) in steps.iter().enumerate() {
+        let n_matches = match_list(needle, haystacks, config).len();
 
-        // One-shot: just measure this single needle from scratch
-        let os = time_avg(iters, || {
+        let os = time_avg(ITERS, || {
             black_box(match_list(black_box(needle), black_box(haystacks), config));
         });
 
-        // Incremental: set up state from prior steps, then measure this step
-        let inc = time_avg(iters, || {
+        // replay prior steps then measure just this one
+        let inc = time_avg(ITERS, || {
             let mut m = IncrementalMatcher::new(config);
-            // Replay prior steps to build up state
-            for &prev in &steps[..step_idx] {
+            for &prev in &steps[..i] {
                 m.match_list(prev, haystacks);
             }
-            // Measure just this step
             black_box(m.match_list(black_box(needle), black_box(haystacks)));
         });
-        // Subtract the setup cost to isolate this step's incremental time
-        let setup = if step_idx > 0 {
-            time_avg(iters, || {
+        let setup = if i > 0 {
+            time_avg(ITERS, || {
                 let mut m = IncrementalMatcher::new(config);
-                for &prev in &steps[..step_idx] {
+                for &prev in &steps[..i] {
                     m.match_list(prev, haystacks);
                 }
             })
@@ -154,30 +84,32 @@ fn bench_query(haystacks: &[&str], steps: &[&str], label: &str, config: &Config)
         };
         let inc_step = inc.saturating_sub(setup);
 
-        // Guard against measurement noise where setup ≈ total
-        let (inc_display, speedup_display) = if inc_step.as_nanos() == 0 {
-            ("~0".to_string(), ">99".to_string())
+        if inc_step.as_nanos() == 0 {
+            println!(
+                "    {:>10} {:>8} {:>10.2?} {:>10} {:>6}x",
+                format!("{:?}", needle),
+                n_matches,
+                os,
+                "~0",
+                ">99"
+            );
         } else {
             let speedup = os.as_nanos() as f64 / inc_step.as_nanos() as f64;
-            (format!("{:.2?}", inc_step), format!("{:.1}", speedup))
-        };
-
-        println!(
-            "    {:>10} {:>8} {:>10.2?} {:>10} {:>6}x",
-            format!("{:?}", needle),
-            matches,
-            os,
-            inc_display,
-            speedup_display,
-        );
+            println!(
+                "    {:>10} {:>8} {:>10.2?} {:>10.2?} {:>5.1}x",
+                format!("{:?}", needle),
+                n_matches,
+                os,
+                inc_step,
+                speedup
+            );
+        }
     }
     println!();
 }
 
 fn time_avg(iters: u32, mut f: impl FnMut()) -> Duration {
-    // Warmup
-    f();
-
+    f(); // warmup
     let start = Instant::now();
     for _ in 0..iters {
         f();
@@ -185,65 +117,85 @@ fn time_avg(iters: u32, mut f: impl FnMut()) -> Duration {
     start.elapsed() / iters
 }
 
-/// Generate realistic file-path-like haystacks (e.g. "src/components/ButtonList.tsx")
-fn generate_file_paths(count: usize, seed: u64) -> Vec<String> {
+/// Generates paths like "src/components/ButtonList.tsx"
+fn gen_paths(count: usize, seed: u64) -> Vec<String> {
     let mut rng = StdRng::seed_from_u64(seed);
+    let depth_dist = Normal::new(3.0, 1.0).unwrap();
 
     let dirs = [
-        "src", "lib", "test", "docs", "build", "config", "scripts", "assets",
-        "public", "vendor", "internal", "pkg", "cmd", "api", "web",
+        "src", "lib", "test", "docs", "build", "config", "scripts", "assets", "public", "vendor",
+        "internal", "pkg", "cmd", "api", "web",
     ];
     let subdirs = [
-        "components", "utils", "hooks", "services", "models", "views",
-        "controllers", "middleware", "helpers", "types", "constants",
-        "store", "actions", "reducers", "selectors", "pages", "layouts",
-        "widgets", "auth", "config", "db", "cache", "queue", "workers",
+        "components",
+        "utils",
+        "hooks",
+        "services",
+        "models",
+        "views",
+        "controllers",
+        "middleware",
+        "helpers",
+        "types",
+        "store",
+        "pages",
+        "layouts",
+        "widgets",
+        "auth",
+        "db",
+        "cache",
     ];
-    let prefixes = [
-        "Button", "Input", "Modal", "Table", "Form", "List", "Card", "Nav",
-        "Header", "Footer", "Sidebar", "Menu", "Dialog", "Panel", "Tab",
-        "Search", "Filter", "Sort", "Page", "App", "User", "Auth", "Data",
-        "Event", "File", "Image", "Video", "Audio", "Chart", "Graph",
-        "Config", "Cache", "Queue", "Worker", "Handler", "Manager",
+    let names = [
+        "Button", "Input", "Modal", "Table", "Form", "List", "Card", "Nav", "Header", "Footer",
+        "Sidebar", "Menu", "Dialog", "Panel", "Search", "Filter", "Sort", "Page", "App", "User",
+        "Auth", "Data", "Config", "Cache", "Handler", "Manager",
     ];
-    let suffixes = [
-        "", "Item", "List", "View", "Detail", "Edit", "Create", "Delete",
-        "Update", "Form", "Modal", "Page", "Layout", "Container", "Wrapper",
-        "Provider", "Context", "Hook", "Service", "Controller", "Model",
-        "Helper", "Util", "Type", "Const", "Action", "Reducer", "Selector",
+    let name_suffixes = [
+        "",
+        "Item",
+        "List",
+        "View",
+        "Detail",
+        "Edit",
+        "Create",
+        "Form",
+        "Page",
+        "Layout",
+        "Container",
+        "Provider",
+        "Context",
+        "Service",
+        "Controller",
+        "Helper",
     ];
-    let extensions = [
-        ".rs", ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".java",
-        ".css", ".scss", ".html", ".json", ".toml", ".yaml", ".md",
+    let exts = [
+        ".rs", ".ts", ".tsx", ".js", ".py", ".go", ".java", ".css", ".json", ".toml", ".md",
     ];
-
-    let normal = Normal::new(3.0, 1.0).unwrap();
 
     (0..count)
         .map(|_| {
-            // Random depth 1-5
-            let depth = (normal.sample(&mut rng) as f64).round().abs().max(1.0) as usize;
-            let depth = depth.min(5);
+            let depth = (depth_dist.sample(&mut rng) as f64)
+                .round()
+                .abs()
+                .max(1.0)
+                .min(5.0) as usize;
             let mut parts = Vec::with_capacity(depth + 1);
 
-            parts.push(dirs[rng.random_range(0..dirs.len())].to_string());
+            parts.push(dirs[rng.random_range(0..dirs.len())]);
             for _ in 1..depth {
-                parts.push(subdirs[rng.random_range(0..subdirs.len())].to_string());
+                parts.push(subdirs[rng.random_range(0..subdirs.len())]);
             }
 
-            let prefix = prefixes[rng.random_range(0..prefixes.len())];
-            let suffix = suffixes[rng.random_range(0..suffixes.len())];
-            let ext = extensions[rng.random_range(0..extensions.len())];
-
-            // Occasionally add a numeric suffix
+            let name = names[rng.random_range(0..names.len())];
+            let suffix = name_suffixes[rng.random_range(0..name_suffixes.len())];
+            let ext = exts[rng.random_range(0..exts.len())];
             let num = if rng.random_ratio(1, 5) {
-                format!("{}", rng.random_range(1..100u32))
+                rng.random_range(1..100u32).to_string()
             } else {
                 String::new()
             };
 
-            parts.push(format!("{}{}{}{}", prefix, suffix, num, ext));
-            parts.join("/")
+            format!("{}/{name}{suffix}{num}{ext}", parts.join("/"))
         })
         .collect()
 }

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -1,0 +1,249 @@
+//! Benchmark: IncrementalMatcher vs one-shot match_list
+//!
+//! Measures the real-world benefit of incremental matching when a user types
+//! a query character by character. Tests multiple query patterns, dataset sizes,
+//! and shows per-step breakdowns where the narrowing effect is visible.
+
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use rand::prelude::*;
+use rand_distr::{Distribution, Normal};
+
+use frizbee::{Config, IncrementalMatcher, match_list};
+
+fn main() {
+    let config = Config::default();
+
+    // ============================================================
+    // 1. File-path dataset (realistic fuzzy finder workload)
+    // ============================================================
+    println!("=== File-Path Dataset (simulated project tree) ===\n");
+
+    for &count in &[50_000usize, 200_000, 500_000] {
+        let haystacks = generate_file_paths(count, 42);
+        let refs: Vec<&str> = haystacks.iter().map(|s| s.as_str()).collect();
+
+        // Multiple query patterns that resemble real fuzzy finder usage
+        let queries: &[(&str, &[&str])] = &[
+            // Searching for a file by abbreviation (high selectivity)
+            ("mch", &["m", "mc", "mch"]),
+            // Typing a common path segment (low selectivity early, high later)
+            ("src/comp", &["s", "sr", "src", "src/", "src/c", "src/co", "src/com", "src/comp"]),
+            // CamelCase search for a component name
+            ("BtLs", &["B", "Bt", "BtL", "BtLs"]),
+        ];
+
+        println!("--- {} haystacks ---\n", count);
+
+        for &(label, steps) in queries {
+            bench_query(&refs, steps, label, &config);
+        }
+    }
+
+    // ============================================================
+    // 2. Selectivity comparison
+    // ============================================================
+    println!("\n=== Selectivity Impact ===\n");
+    println!("Shows how incremental speedup varies with match ratio.\n");
+
+    let haystacks = generate_file_paths(200_000, 42);
+    let refs: Vec<&str> = haystacks.iter().map(|s| s.as_str()).collect();
+
+    // Pairs: (query, description) — ordered by expected selectivity (high match% → low match%)
+    let selectivity_queries: &[(&[&str], &str)] = &[
+        (&["s", "sr", "src"], "common prefix (high match%)"),
+        (&["c", "co", "com", "comp"], "medium selectivity"),
+        (&["B", "Bt", "BtL", "BtLs"], "CamelCase (low match%)"),
+        (&["z", "zx", "zxq"], "rare chars (very low match%)"),
+    ];
+
+    println!(
+        "  {:30} {:>10} {:>10} {:>7} {:>10}",
+        "Query", "One-shot", "Incremental", "Speedup", "Final matches"
+    );
+    println!("  {}", "-".repeat(71));
+
+    for &(steps, desc) in selectivity_queries {
+        let final_needle = steps.last().unwrap();
+        let final_matches = match_list(final_needle, &refs, &config).len();
+
+        let iters = 20u32;
+        let one_shot = time_avg(iters, || {
+            for &n in steps {
+                black_box(match_list(n, black_box(&refs), &config));
+            }
+        });
+        let incr = time_avg(iters, || {
+            let mut m = IncrementalMatcher::new(&config);
+            for &n in steps {
+                black_box(m.match_list(n, black_box(&refs)));
+            }
+        });
+
+        println!(
+            "  {:30} {:>10.2?} {:>10.2?} {:>6.2}x {:>10}",
+            format!("{:?} ({})", steps.last().unwrap(), desc),
+            one_shot,
+            incr,
+            one_shot.as_nanos() as f64 / incr.as_nanos() as f64,
+            final_matches,
+        );
+    }
+}
+
+/// Benchmark a single query pattern: overall + per-step breakdown
+fn bench_query(haystacks: &[&str], steps: &[&str], label: &str, config: &Config) {
+    let iters = 20u32;
+
+    // Overall timing
+    let one_shot_total = time_avg(iters, || {
+        for &n in steps {
+            black_box(match_list(n, black_box(haystacks), config));
+        }
+    });
+    let incr_total = time_avg(iters, || {
+        let mut m = IncrementalMatcher::new(config);
+        for &n in steps {
+            black_box(m.match_list(n, black_box(haystacks)));
+        }
+    });
+
+    println!("  Query {:?} ({} steps)", label, steps.len());
+    println!(
+        "    Overall:  one-shot {:>9.2?}  incremental {:>9.2?}  ({:.2}x)",
+        one_shot_total,
+        incr_total,
+        one_shot_total.as_nanos() as f64 / incr_total.as_nanos() as f64,
+    );
+
+    // Per-step breakdown
+    println!(
+        "    {:>10} {:>8} {:>10} {:>10} {:>7}",
+        "Needle", "Matches", "One-shot", "Incremental", "Speedup"
+    );
+
+    for (step_idx, &needle) in steps.iter().enumerate() {
+        let matches = match_list(needle, haystacks, config).len();
+
+        // One-shot: just measure this single needle from scratch
+        let os = time_avg(iters, || {
+            black_box(match_list(black_box(needle), black_box(haystacks), config));
+        });
+
+        // Incremental: set up state from prior steps, then measure this step
+        let inc = time_avg(iters, || {
+            let mut m = IncrementalMatcher::new(config);
+            // Replay prior steps to build up state
+            for &prev in &steps[..step_idx] {
+                m.match_list(prev, haystacks);
+            }
+            // Measure just this step
+            black_box(m.match_list(black_box(needle), black_box(haystacks)));
+        });
+        // Subtract the setup cost to isolate this step's incremental time
+        let setup = if step_idx > 0 {
+            time_avg(iters, || {
+                let mut m = IncrementalMatcher::new(config);
+                for &prev in &steps[..step_idx] {
+                    m.match_list(prev, haystacks);
+                }
+            })
+        } else {
+            Duration::ZERO
+        };
+        let inc_step = inc.saturating_sub(setup);
+
+        // Guard against measurement noise where setup ≈ total
+        let (inc_display, speedup_display) = if inc_step.as_nanos() == 0 {
+            ("~0".to_string(), ">99".to_string())
+        } else {
+            let speedup = os.as_nanos() as f64 / inc_step.as_nanos() as f64;
+            (format!("{:.2?}", inc_step), format!("{:.1}", speedup))
+        };
+
+        println!(
+            "    {:>10} {:>8} {:>10.2?} {:>10} {:>6}x",
+            format!("{:?}", needle),
+            matches,
+            os,
+            inc_display,
+            speedup_display,
+        );
+    }
+    println!();
+}
+
+fn time_avg(iters: u32, mut f: impl FnMut()) -> Duration {
+    // Warmup
+    f();
+
+    let start = Instant::now();
+    for _ in 0..iters {
+        f();
+    }
+    start.elapsed() / iters
+}
+
+/// Generate realistic file-path-like haystacks (e.g. "src/components/ButtonList.tsx")
+fn generate_file_paths(count: usize, seed: u64) -> Vec<String> {
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    let dirs = [
+        "src", "lib", "test", "docs", "build", "config", "scripts", "assets",
+        "public", "vendor", "internal", "pkg", "cmd", "api", "web",
+    ];
+    let subdirs = [
+        "components", "utils", "hooks", "services", "models", "views",
+        "controllers", "middleware", "helpers", "types", "constants",
+        "store", "actions", "reducers", "selectors", "pages", "layouts",
+        "widgets", "auth", "config", "db", "cache", "queue", "workers",
+    ];
+    let prefixes = [
+        "Button", "Input", "Modal", "Table", "Form", "List", "Card", "Nav",
+        "Header", "Footer", "Sidebar", "Menu", "Dialog", "Panel", "Tab",
+        "Search", "Filter", "Sort", "Page", "App", "User", "Auth", "Data",
+        "Event", "File", "Image", "Video", "Audio", "Chart", "Graph",
+        "Config", "Cache", "Queue", "Worker", "Handler", "Manager",
+    ];
+    let suffixes = [
+        "", "Item", "List", "View", "Detail", "Edit", "Create", "Delete",
+        "Update", "Form", "Modal", "Page", "Layout", "Container", "Wrapper",
+        "Provider", "Context", "Hook", "Service", "Controller", "Model",
+        "Helper", "Util", "Type", "Const", "Action", "Reducer", "Selector",
+    ];
+    let extensions = [
+        ".rs", ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".java",
+        ".css", ".scss", ".html", ".json", ".toml", ".yaml", ".md",
+    ];
+
+    let normal = Normal::new(3.0, 1.0).unwrap();
+
+    (0..count)
+        .map(|_| {
+            // Random depth 1-5
+            let depth = (normal.sample(&mut rng) as f64).round().abs().max(1.0) as usize;
+            let depth = depth.min(5);
+            let mut parts = Vec::with_capacity(depth + 1);
+
+            parts.push(dirs[rng.random_range(0..dirs.len())].to_string());
+            for _ in 1..depth {
+                parts.push(subdirs[rng.random_range(0..subdirs.len())].to_string());
+            }
+
+            let prefix = prefixes[rng.random_range(0..prefixes.len())];
+            let suffix = suffixes[rng.random_range(0..suffixes.len())];
+            let ext = extensions[rng.random_range(0..extensions.len())];
+
+            // Occasionally add a numeric suffix
+            let num = if rng.random_ratio(1, 5) {
+                format!("{}", rng.random_range(1..100u32))
+            } else {
+                String::new()
+            };
+
+            parts.push(format!("{}{}{}{}", prefix, suffix, num, ext));
+            parts.join("/")
+        })
+        .collect()
+}

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -11,7 +11,7 @@ const ITERS: u32 = 20;
 fn main() {
     let config = Config::default();
 
-    for &count in &[50_000usize, 200_000, 500_000] {
+    for &count in &[500_000, 1_000_000] {
         let haystacks = gen_paths(count, 42);
         let refs: Vec<&str> = haystacks.iter().map(|s| s.as_str()).collect();
 
@@ -31,7 +31,9 @@ fn main() {
         println!("  -- backspace --\n");
         bench_backspace(
             &refs,
-            &["s", "sr", "src", "src/", "src/c", "src/co", "src/com", "src/comp"],
+            &[
+                "s", "sr", "src", "src/", "src/c", "src/co", "src/com", "src/comp",
+            ],
             &config,
         );
     }
@@ -44,9 +46,9 @@ fn bench_query(haystacks: &[&str], steps: &[&str], config: &Config) {
         }
     });
     let incr_total = time_avg(ITERS, || {
-        let mut m = IncrementalMatcher::new(config);
+        let mut m = IncrementalMatcher::new(config, black_box(haystacks));
         for &n in steps {
-            black_box(m.match_list(n, black_box(haystacks)));
+            black_box(m.match_list(n));
         }
     });
 
@@ -73,17 +75,17 @@ fn bench_query(haystacks: &[&str], steps: &[&str], config: &Config) {
 
         // replay prior steps then measure just this one
         let inc = time_avg(ITERS, || {
-            let mut m = IncrementalMatcher::new(config);
+            let mut m = IncrementalMatcher::new(config, black_box(haystacks));
             for &prev in &steps[..i] {
-                m.match_list(prev, haystacks);
+                m.match_list(prev);
             }
-            black_box(m.match_list(black_box(needle), black_box(haystacks)));
+            black_box(m.match_list(black_box(needle)));
         });
         let setup = if i > 0 {
             time_avg(ITERS, || {
-                let mut m = IncrementalMatcher::new(config);
+                let mut m = IncrementalMatcher::new(config, black_box(haystacks));
                 for &prev in &steps[..i] {
-                    m.match_list(prev, haystacks);
+                    m.match_list(prev);
                 }
             })
         } else {
@@ -129,26 +131,23 @@ fn bench_backspace(haystacks: &[&str], steps: &[&str], config: &Config) {
 
         // type forward to the end, then backspace to `back_to`
         let inc = time_avg(ITERS, || {
-            let mut m = IncrementalMatcher::new(config);
+            let mut m = IncrementalMatcher::new(config, black_box(haystacks));
             for &s in steps {
-                m.match_list(s, haystacks);
+                m.match_list(s);
             }
-            black_box(m.match_list(black_box(needle), black_box(haystacks)));
+            black_box(m.match_list(black_box(needle)));
         });
         let setup = time_avg(ITERS, || {
-            let mut m = IncrementalMatcher::new(config);
+            let mut m = IncrementalMatcher::new(config, black_box(haystacks));
             for &s in steps {
-                m.match_list(s, haystacks);
+                m.match_list(s);
             }
         });
         let inc_step = inc.saturating_sub(setup);
 
         let label = format!("{:?}->{:?}", steps.last().unwrap(), needle);
         if inc_step.as_nanos() == 0 {
-            println!(
-                "    {:>10} {:>10.2?} {:>10} {:>6}x",
-                label, os, "~0", ">99"
-            );
+            println!("    {:>10} {:>10.2?} {:>10} {:>6}x", label, os, "~0", ">99");
         } else {
             let speedup = os.as_nanos() as f64 / inc_step.as_nanos() as f64;
             println!(

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -1,0 +1,783 @@
+use itertools::Itertools;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+use crate::one_shot::Matcher;
+use crate::{Config, Match, MatchIndices};
+
+/// Incremental fuzzy matcher that reuses previous results when the needle is extended.
+///
+/// When a user types a query character by character (e.g. `"f"` → `"fo"` → `"foo"`),
+/// extending a needle can only eliminate matches, never create new ones. This matcher
+/// stores which haystack indices matched previously and only rescores that subset when
+/// the new needle is a prefix extension of the previous one.
+///
+/// # Example
+///
+/// ```rust
+/// use frizbee::{IncrementalMatcher, Config};
+///
+/// let haystacks = ["fooBar", "foo_bar", "prelude", "println!"];
+/// let mut matcher = IncrementalMatcher::new(&Config::default());
+///
+/// let matches = matcher.match_list("f", &haystacks);
+/// let matches = matcher.match_list("fo", &haystacks);
+/// let matches = matcher.match_list("foo", &haystacks);
+/// ```
+pub struct IncrementalMatcher {
+    matcher: Matcher,
+    prev_needle: String,
+    matched_indices: Vec<u32>,
+    prev_haystack_count: usize,
+}
+
+impl IncrementalMatcher {
+    pub fn new(config: &Config) -> Self {
+        Self {
+            matcher: Matcher::new("", config),
+            prev_needle: String::new(),
+            matched_indices: Vec::new(),
+            prev_haystack_count: 0,
+        }
+    }
+
+    /// Match the needle against the haystacks, reusing previous results when possible.
+    pub fn match_list<S: AsRef<str>>(&mut self, needle: &str, haystacks: &[S]) -> Vec<Match> {
+        let is_prefix_extension = self.is_prefix_extension(needle);
+        let haystack_count = haystacks.len();
+
+        self.matcher.set_needle(needle);
+
+        if needle.is_empty() {
+            self.prev_needle.clear();
+            self.matched_indices.clear();
+            self.prev_haystack_count = haystack_count;
+            return (0..haystack_count).map(Match::from_index).collect();
+        }
+
+        if is_prefix_extension && haystack_count == self.prev_haystack_count {
+            let mut matches = self.match_narrowed_unsorted(haystacks);
+            if self.matcher.config.sort {
+                matches.sort_unstable();
+            }
+            self.set_prev(needle, haystack_count);
+            matches
+        } else if is_prefix_extension && haystack_count > self.prev_haystack_count {
+            let matches = self.match_narrowed_with_growth(haystacks);
+            self.set_prev(needle, haystack_count);
+            matches
+        } else {
+            self.full_rescore(haystacks, needle, haystack_count)
+        }
+    }
+
+    /// Match the needle against the haystacks with character match indices.
+    pub fn match_list_indices<S: AsRef<str>>(
+        &mut self,
+        needle: &str,
+        haystacks: &[S],
+    ) -> Vec<MatchIndices> {
+        let is_prefix_extension = self.is_prefix_extension(needle);
+        let haystack_count = haystacks.len();
+
+        self.matcher.set_needle(needle);
+
+        if needle.is_empty() {
+            self.prev_needle.clear();
+            self.matched_indices.clear();
+            self.prev_haystack_count = haystack_count;
+            return (0..haystack_count).map(MatchIndices::from_index).collect();
+        }
+
+        if is_prefix_extension && haystack_count == self.prev_haystack_count {
+            let mut matches = self.match_narrowed_indices_unsorted(haystacks);
+            if self.matcher.config.sort {
+                matches.sort_unstable();
+            }
+            self.set_prev(needle, haystack_count);
+            matches
+        } else if is_prefix_extension && haystack_count > self.prev_haystack_count {
+            let matches = self.match_narrowed_indices_with_growth(haystacks);
+            self.set_prev(needle, haystack_count);
+            matches
+        } else {
+            self.full_rescore_indices(haystacks, needle, haystack_count)
+        }
+    }
+
+    /// Match the needle against the haystacks in parallel.
+    pub fn match_list_parallel<S: AsRef<str> + Sync>(
+        &mut self,
+        needle: &str,
+        haystacks: &[S],
+        threads: usize,
+    ) -> Vec<Match> {
+        let is_prefix_extension = self.is_prefix_extension(needle);
+        let haystack_count = haystacks.len();
+
+        self.matcher.set_needle(needle);
+
+        if needle.is_empty() {
+            self.prev_needle.clear();
+            self.matched_indices.clear();
+            self.prev_haystack_count = haystack_count;
+            return (0..haystack_count).map(Match::from_index).collect();
+        }
+
+        if is_prefix_extension && haystack_count >= self.prev_haystack_count {
+            let matches = self.match_narrowed_parallel(haystacks, threads);
+            self.set_prev(needle, haystack_count);
+            matches
+        } else {
+            let matches = self.full_rescore_parallel(haystacks, threads);
+            self.update_state_from_matches(needle, haystack_count, matches.iter().map(|m| m.index));
+            matches
+        }
+    }
+
+    /// Reset the incremental state, forcing a full rescore on the next call.
+    pub fn reset(&mut self) {
+        self.prev_needle.clear();
+        self.matched_indices.clear();
+        self.prev_haystack_count = 0;
+    }
+
+    pub fn matcher(&self) -> &Matcher {
+        &self.matcher
+    }
+
+    #[inline(always)]
+    fn is_prefix_extension(&self, needle: &str) -> bool {
+        !self.prev_needle.is_empty()
+            && needle.len() > self.prev_needle.len()
+            && needle.starts_with(&self.prev_needle)
+    }
+
+    #[inline]
+    fn set_prev(&mut self, needle: &str, haystack_count: usize) {
+        self.prev_needle.clear();
+        self.prev_needle.push_str(needle);
+        self.prev_haystack_count = haystack_count;
+    }
+
+    #[inline]
+    fn update_state_from_matches(
+        &mut self,
+        needle: &str,
+        haystack_count: usize,
+        indices: impl Iterator<Item = u32>,
+    ) {
+        self.prev_needle.clear();
+        self.prev_needle.push_str(needle);
+        self.matched_indices.clear();
+        self.matched_indices.extend(indices);
+        self.matched_indices.sort_unstable();
+        self.prev_haystack_count = haystack_count;
+    }
+
+    #[inline]
+    fn full_rescore<S: AsRef<str>>(
+        &mut self,
+        haystacks: &[S],
+        needle: &str,
+        haystack_count: usize,
+    ) -> Vec<Match> {
+        let mut matches = Vec::new();
+        self.matcher.match_list_into(haystacks, 0, &mut matches);
+
+        // Extract indices while in insertion order (ascending)
+        self.matched_indices.clear();
+        self.matched_indices.extend(matches.iter().map(|m| m.index));
+
+        if self.matcher.config.sort {
+            matches.sort_unstable();
+        }
+
+        self.set_prev(needle, haystack_count);
+        matches
+    }
+
+    #[inline]
+    fn full_rescore_indices<S: AsRef<str>>(
+        &mut self,
+        haystacks: &[S],
+        needle: &str,
+        haystack_count: usize,
+    ) -> Vec<MatchIndices> {
+        let mut matches = Vec::new();
+        self.matcher
+            .match_list_indices_into(haystacks, 0, &mut matches);
+
+        self.matched_indices.clear();
+        self.matched_indices.extend(matches.iter().map(|m| m.index));
+
+        if self.matcher.config.sort {
+            matches.sort_unstable();
+        }
+
+        self.set_prev(needle, haystack_count);
+        matches
+    }
+
+    #[inline]
+    fn match_narrowed_unsorted<S: AsRef<str>>(&mut self, haystacks: &[S]) -> Vec<Match> {
+        let mut matches = Vec::with_capacity(self.matched_indices.len());
+        let max_typos = self.matcher.config.max_typos;
+        let needle_len = self.matcher.needle.len();
+        let min_haystack_len = max_typos
+            .map(|max| needle_len.saturating_sub(max as usize))
+            .unwrap_or(0);
+
+        let mut write = 0usize;
+        for read in 0..self.matched_indices.len() {
+            let idx = self.matched_indices[read];
+            let haystack = haystacks[idx as usize].as_ref().as_bytes();
+
+            if haystack.len() < min_haystack_len {
+                continue;
+            }
+
+            let (matched, skipped_chunks) = match max_typos {
+                Some(max) => self.matcher.prefilter.match_haystack(haystack, max),
+                None => (true, 0),
+            };
+            if !matched {
+                continue;
+            }
+
+            let trimmed = &haystack[skipped_chunks * 16..];
+            if let Some(m) =
+                self.matcher
+                    .smith_waterman_one(trimmed, idx, skipped_chunks == 0)
+            {
+                self.matched_indices[write] = idx;
+                write += 1;
+                matches.push(m);
+            }
+        }
+        self.matched_indices.truncate(write);
+
+        matches
+    }
+
+    fn match_narrowed_with_growth<S: AsRef<str>>(&mut self, haystacks: &[S]) -> Vec<Match> {
+        let mut matches = self.match_narrowed_unsorted(haystacks);
+
+        let prev_count = self.prev_haystack_count;
+        let matches_before_tail = matches.len();
+        self.matcher
+            .match_list_into(&haystacks[prev_count..], prev_count as u32, &mut matches);
+        self.matched_indices
+            .extend(matches[matches_before_tail..].iter().map(|m| m.index));
+
+        if self.matcher.config.sort {
+            matches.sort_unstable();
+        }
+
+        matches
+    }
+
+    #[inline]
+    fn match_narrowed_indices_unsorted<S: AsRef<str>>(
+        &mut self,
+        haystacks: &[S],
+    ) -> Vec<MatchIndices> {
+        let mut matches = Vec::with_capacity(self.matched_indices.len());
+        let max_typos = self.matcher.config.max_typos;
+        let needle_len = self.matcher.needle.len();
+        let min_haystack_len = max_typos
+            .map(|max| needle_len.saturating_sub(max as usize))
+            .unwrap_or(0);
+
+        let mut write = 0usize;
+        for read in 0..self.matched_indices.len() {
+            let idx = self.matched_indices[read];
+            let haystack = haystacks[idx as usize].as_ref().as_bytes();
+
+            if haystack.len() < min_haystack_len {
+                continue;
+            }
+
+            let (matched, skipped_chunks) = match max_typos {
+                Some(max) => self.matcher.prefilter.match_haystack(haystack, max),
+                None => (true, 0),
+            };
+            if !matched {
+                continue;
+            }
+
+            let trimmed = &haystack[skipped_chunks * 16..];
+            if let Some(m) = self.matcher.smith_waterman_indices_one(
+                trimmed,
+                skipped_chunks,
+                idx,
+                skipped_chunks == 0,
+            ) {
+                self.matched_indices[write] = idx;
+                write += 1;
+                matches.push(m);
+            }
+        }
+        self.matched_indices.truncate(write);
+
+        matches
+    }
+
+    fn match_narrowed_indices_with_growth<S: AsRef<str>>(
+        &mut self,
+        haystacks: &[S],
+    ) -> Vec<MatchIndices> {
+        let mut matches = self.match_narrowed_indices_unsorted(haystacks);
+
+        let prev_count = self.prev_haystack_count;
+        let matches_before_tail = matches.len();
+        self.matcher
+            .match_list_indices_into(&haystacks[prev_count..], prev_count as u32, &mut matches);
+        self.matched_indices
+            .extend(matches[matches_before_tail..].iter().map(|m| m.index));
+
+        if self.matcher.config.sort {
+            matches.sort_unstable();
+        }
+
+        matches
+    }
+
+    fn full_rescore_parallel<S: AsRef<str> + Sync>(
+        &self,
+        haystacks: &[S],
+        threads: usize,
+    ) -> Vec<Match> {
+        if haystacks.is_empty() {
+            return vec![];
+        }
+
+        let chunk_size = 512;
+        let num_chunks = haystacks.len().div_ceil(chunk_size);
+        let next_chunk = AtomicUsize::new(0);
+        let matcher = &self.matcher;
+        let config = &matcher.config;
+
+        thread::scope(|s| {
+            let handles: Vec<_> = (0..threads)
+                .map(|_| {
+                    s.spawn(|| {
+                        let mut local_matches = Vec::new();
+                        let mut thread_matcher = matcher.clone();
+
+                        loop {
+                            let chunk_idx = next_chunk.fetch_add(1, Ordering::Relaxed);
+                            if chunk_idx >= num_chunks {
+                                break;
+                            }
+
+                            let start = chunk_idx * chunk_size;
+                            let end = (start + chunk_size).min(haystacks.len());
+
+                            thread_matcher.match_list_into(
+                                &haystacks[start..end],
+                                start as u32,
+                                &mut local_matches,
+                            );
+                        }
+
+                        if config.sort {
+                            local_matches.sort_unstable();
+                        }
+
+                        local_matches
+                    })
+                })
+                .collect();
+
+            if config.sort {
+                handles
+                    .into_iter()
+                    .map(|h| h.join().unwrap())
+                    .kmerge()
+                    .collect()
+            } else {
+                handles
+                    .into_iter()
+                    .flat_map(|h| h.join().unwrap())
+                    .collect()
+            }
+        })
+    }
+
+    fn match_narrowed_parallel<S: AsRef<str> + Sync>(
+        &mut self,
+        haystacks: &[S],
+        threads: usize,
+    ) -> Vec<Match> {
+        let mut new_tail_matches = Vec::new();
+        let mut new_tail_indices = Vec::new();
+        if haystacks.len() > self.prev_haystack_count {
+            let prev_count = self.prev_haystack_count;
+            self.matcher.match_list_into(
+                &haystacks[prev_count..],
+                prev_count as u32,
+                &mut new_tail_matches,
+            );
+            new_tail_indices.extend(new_tail_matches.iter().map(|m| m.index));
+        }
+
+        if self.matched_indices.is_empty() {
+            self.matched_indices = new_tail_indices;
+            if self.matcher.config.sort {
+                new_tail_matches.sort_unstable();
+            }
+            return new_tail_matches;
+        }
+
+        let chunk_size = 512;
+        let num_chunks = self.matched_indices.len().div_ceil(chunk_size);
+        let next_chunk = AtomicUsize::new(0);
+
+        let matched_indices = &self.matched_indices;
+        let matcher = &self.matcher;
+        let config = &matcher.config;
+        let max_typos = config.max_typos;
+        let needle_len = matcher.needle.len();
+        let min_haystack_len = max_typos
+            .map(|max| needle_len.saturating_sub(max as usize))
+            .unwrap_or(0);
+
+        let (thread_matches, new_indices) = thread::scope(|s| {
+            let handles: Vec<_> = (0..threads)
+                .map(|_| {
+                    s.spawn(|| {
+                        let mut local_matches = Vec::new();
+                        let mut local_indices = Vec::new();
+                        let mut thread_matcher = matcher.clone();
+
+                        loop {
+                            let chunk_idx = next_chunk.fetch_add(1, Ordering::Relaxed);
+                            if chunk_idx >= num_chunks {
+                                break;
+                            }
+
+                            let start = chunk_idx * chunk_size;
+                            let end = (start + chunk_size).min(matched_indices.len());
+
+                            for &idx in &matched_indices[start..end] {
+                                let haystack = haystacks[idx as usize].as_ref().as_bytes();
+
+                                if haystack.len() < min_haystack_len {
+                                    continue;
+                                }
+
+                                let (matched, skipped_chunks) = match max_typos {
+                                    Some(max) => {
+                                        thread_matcher.prefilter.match_haystack(haystack, max)
+                                    }
+                                    None => (true, 0),
+                                };
+                                if !matched {
+                                    continue;
+                                }
+
+                                let trimmed = &haystack[skipped_chunks * 16..];
+                                if let Some(m) = thread_matcher.smith_waterman_one(
+                                    trimmed,
+                                    idx,
+                                    skipped_chunks == 0,
+                                ) {
+                                    local_matches.push(m);
+                                    local_indices.push(idx);
+                                }
+                            }
+                        }
+
+                        if config.sort {
+                            local_matches.sort_unstable();
+                        }
+
+                        (local_matches, local_indices)
+                    })
+                })
+                .collect();
+
+            let mut all_indices = Vec::new();
+            let thread_matches = if config.sort {
+                let mut match_vecs = Vec::with_capacity(handles.len());
+                for h in handles {
+                    let (matches, indices) = h.join().unwrap();
+                    all_indices.extend(indices);
+                    match_vecs.push(matches);
+                }
+                match_vecs.into_iter().kmerge().collect::<Vec<Match>>()
+            } else {
+                let mut all_matches = Vec::new();
+                for h in handles {
+                    let (matches, indices) = h.join().unwrap();
+                    all_indices.extend(indices);
+                    all_matches.extend(matches);
+                }
+                all_matches
+            };
+            (thread_matches, all_indices)
+        });
+
+        self.matched_indices = new_indices;
+        self.matched_indices.sort_unstable();
+        self.matched_indices.extend(new_tail_indices);
+
+        if new_tail_matches.is_empty() {
+            thread_matches
+        } else if config.sort {
+            thread_matches
+                .into_iter()
+                .merge(new_tail_matches)
+                .collect()
+        } else {
+            let mut result = thread_matches;
+            result.extend(new_tail_matches);
+            result
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::match_list;
+
+    fn assert_match_parity(needle: &str, haystacks: &[&str], config: &Config) {
+        let expected = match_list(needle, haystacks, config);
+        let mut incr = IncrementalMatcher::new(config);
+        let actual = incr.match_list(needle, haystacks);
+        assert_eq!(
+            actual, expected,
+            "mismatch for needle {:?}: actual={:?}, expected={:?}",
+            needle, actual, expected
+        );
+    }
+
+    #[test]
+    fn incremental_matches_one_shot() {
+        let haystacks = [
+            "fooBar",
+            "foo_bar",
+            "prelude",
+            "println!",
+            "fizzBuzz",
+            "format!",
+        ];
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        for needle in ["f", "fo", "foo", "fooB", "fooBar"] {
+            let expected = match_list(needle, &haystacks, &config);
+            let actual = incr.match_list(needle, &haystacks);
+            assert_eq!(actual, expected, "mismatch for needle {:?}", needle);
+        }
+    }
+
+    #[test]
+    fn prefix_extension_narrows() {
+        let haystacks = ["fooBar", "foo_bar", "prelude", "println!", "format!"];
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        let m1 = incr.match_list("f", &haystacks);
+        assert!(!m1.is_empty());
+
+        let m2 = incr.match_list("fo", &haystacks);
+        assert!(m2.len() <= m1.len());
+
+        let m3 = incr.match_list("foo", &haystacks);
+        assert!(m3.len() <= m2.len());
+
+        for needle in ["f", "fo", "foo"] {
+            assert_match_parity(needle, &haystacks, &config);
+        }
+    }
+
+    #[test]
+    fn non_prefix_change_full_rescore() {
+        let haystacks = ["fooBar", "barBaz", "bazQux"];
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        let m1 = incr.match_list("foo", &haystacks);
+        let m2 = incr.match_list("bar", &haystacks);
+
+        let expected = match_list("bar", &haystacks, &config);
+        assert_eq!(m2, expected);
+        assert_ne!(
+            m1.iter().map(|m| m.index).collect::<Vec<_>>(),
+            m2.iter().map(|m| m.index).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn deletion_full_rescore() {
+        let haystacks = ["fooBar", "foo_bar", "fBaz"];
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        incr.match_list("foo", &haystacks);
+        let m = incr.match_list("fo", &haystacks);
+        let expected = match_list("fo", &haystacks, &config);
+        assert_eq!(m, expected);
+    }
+
+    #[test]
+    fn empty_needle_returns_all() {
+        let haystacks = ["foo", "bar", "baz"];
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        let m = incr.match_list("", &haystacks);
+        assert_eq!(m.len(), 3);
+        for m in &m {
+            assert_eq!(m.score, 0);
+        }
+    }
+
+    #[test]
+    fn haystack_growth() {
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        let haystacks_small: Vec<&str> = vec!["fooBar", "foo_bar", "prelude"];
+        incr.match_list("f", &haystacks_small);
+
+        let haystacks_big: Vec<&str> = vec!["fooBar", "foo_bar", "prelude", "format!", "fizz"];
+        let m2 = incr.match_list("fo", &haystacks_big);
+
+        let expected = match_list("fo", &haystacks_big, &config);
+        assert_eq!(m2, expected);
+    }
+
+    #[test]
+    fn reset_forces_full_rescore() {
+        let haystacks = ["fooBar", "foo_bar"];
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        incr.match_list("f", &haystacks);
+        incr.reset();
+        let m = incr.match_list("fo", &haystacks);
+        let expected = match_list("fo", &haystacks, &config);
+        assert_eq!(m, expected);
+    }
+
+    #[test]
+    fn max_typos_none() {
+        let haystacks = ["fooBar", "fxoBxr", "completely_different"];
+        let config = Config {
+            max_typos: None,
+            ..Config::default()
+        };
+        let mut incr = IncrementalMatcher::new(&config);
+
+        for needle in ["f", "fo", "foo", "fooB"] {
+            let expected = match_list(needle, &haystacks, &config);
+            let actual = incr.match_list(needle, &haystacks);
+            assert_eq!(actual, expected, "mismatch for needle {:?}", needle);
+        }
+    }
+
+    #[test]
+    fn max_typos_one() {
+        let haystacks = ["fooBar", "fxoBar", "fxxBar", "completely_different"];
+        let config = Config {
+            max_typos: Some(1),
+            ..Config::default()
+        };
+        let mut incr = IncrementalMatcher::new(&config);
+
+        for needle in ["f", "fo", "foo", "fooB"] {
+            let expected = match_list(needle, &haystacks, &config);
+            let actual = incr.match_list(needle, &haystacks);
+            assert_eq!(actual, expected, "mismatch for needle {:?}", needle);
+        }
+    }
+
+    #[test]
+    fn high_selectivity() {
+        let mut haystacks: Vec<String> = (0..1000).map(|i| format!("item_{}", i)).collect();
+        haystacks.push("fooBar".to_string());
+        haystacks.push("fooBaz".to_string());
+
+        let refs: Vec<&str> = haystacks.iter().map(|s| s.as_str()).collect();
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        for needle in ["f", "fo", "foo", "fooB", "fooBar"] {
+            let expected = match_list(needle, &refs, &config);
+            let actual = incr.match_list(needle, &refs);
+            assert_eq!(actual, expected, "mismatch for needle {:?}", needle);
+        }
+    }
+
+    #[test]
+    fn low_selectivity() {
+        let haystacks: Vec<String> = (0..100).map(|i| format!("foo_{}", i)).collect();
+        let refs: Vec<&str> = haystacks.iter().map(|s| s.as_str()).collect();
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        for needle in ["f", "fo", "foo", "foo_"] {
+            let expected = match_list(needle, &refs, &config);
+            let actual = incr.match_list(needle, &refs);
+            assert_eq!(actual, expected, "mismatch for needle {:?}", needle);
+        }
+    }
+
+    #[test]
+    fn match_list_indices_parity() {
+        let haystacks = ["fooBar", "foo_bar", "prelude", "println!"];
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        for needle in ["f", "fo", "foo", "fooB"] {
+            let expected = crate::match_list_indices(needle, &haystacks, &config);
+            let actual = incr.match_list_indices(needle, &haystacks);
+            assert_eq!(
+                actual.len(),
+                expected.len(),
+                "length mismatch for needle {:?}",
+                needle
+            );
+            for (a, e) in actual.iter().zip(expected.iter()) {
+                assert_eq!(a.index, e.index, "index mismatch for needle {:?}", needle);
+                assert_eq!(a.score, e.score, "score mismatch for needle {:?}", needle);
+                assert_eq!(a.exact, e.exact, "exact mismatch for needle {:?}", needle);
+                assert_eq!(
+                    a.indices, e.indices,
+                    "indices mismatch for needle {:?}",
+                    needle
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parallel_parity() {
+        let haystacks = [
+            "fooBar", "foo_bar", "prelude", "println!", "format!", "fizzBuzz",
+        ];
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        for needle in ["f", "fo", "foo", "fooB"] {
+            let expected = match_list(needle, &haystacks, &config);
+            let actual = incr.match_list_parallel(needle, &haystacks, 2);
+            assert_eq!(actual, expected, "parallel mismatch for needle {:?}", needle);
+        }
+    }
+
+    #[test]
+    fn same_needle_full_rescore() {
+        let haystacks = ["fooBar", "foo_bar"];
+        let config = Config::default();
+        let mut incr = IncrementalMatcher::new(&config);
+
+        let first = incr.match_list("foo", &haystacks);
+        let second = incr.match_list("foo", &haystacks);
+        assert_eq!(first, second);
+    }
+}

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -1,13 +1,5 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::thread;
-
-use crate::k_merge::k_merge;
 use crate::one_shot::Matcher;
-use crate::{Config, Match, MatchIndices};
-
-fn common_prefix_len(a: &str, b: &str) -> usize {
-    a.bytes().zip(b.bytes()).take_while(|(x, y)| x == y).count()
-}
+use crate::{Config, Match, radix_sort};
 
 /// Incremental fuzzy matcher that reuses previous results when the needle changes.
 ///
@@ -30,502 +22,89 @@ fn common_prefix_len(a: &str, b: &str) -> usize {
 /// // backspace: restores "fo" match set instead of full rescore
 /// let matches = matcher.match_list("fo", &haystacks);
 /// ```
-pub struct IncrementalMatcher {
+pub struct IncrementalMatcher<'a> {
     matcher: Matcher,
-    prev_needle: String,
-    matched_indices: Vec<u32>,
-    prev_haystack_count: usize,
-    index_history: Vec<Option<Vec<u32>>>,
+    haystacks: &'a [&'a str],
+    /// List of needle lengths, each containing a list of haystack string indices
+    /// which were filtered out at the given needle length
+    /// For example, removed_idxs[0] contains the indices of haystacks which were
+    /// filtered out when the needle went from length 0 to length 1.
+    removed_idxs: Vec<Vec<u32>>,
+    /// List of haystack string indices which matched
+    active_matches: Option<Vec<Match>>,
 }
 
-impl IncrementalMatcher {
-    pub fn new(config: &Config) -> Self {
+impl<'a> IncrementalMatcher<'a> {
+    pub fn new(config: &Config, haystacks: &'a [&'a str]) -> Self {
+        let mut config = config.clone();
+        config.sort = false;
+
         Self {
-            matcher: Matcher::new("", config),
-            prev_needle: String::new(),
-            matched_indices: Vec::new(),
-            prev_haystack_count: 0,
-            index_history: Vec::new(),
+            matcher: Matcher::new("", &config),
+            haystacks,
+            removed_idxs: Vec::new(),
+            active_matches: None,
         }
     }
 
-    pub fn match_list<S: AsRef<str>>(&mut self, needle: &str, haystacks: &[S]) -> Vec<Match> {
-        let haystack_count = haystacks.len();
+    pub fn match_list(&mut self, needle: &str) -> Vec<Match> {
+        let prev_needle = &self.matcher.needle.clone();
+        let reusable_level = self.find_reusable_level(needle, prev_needle);
+        let is_prefix_extension = self.is_prefix_extension(needle, prev_needle);
         self.matcher.set_needle(needle);
 
         if needle.is_empty() {
             self.reset();
-            self.prev_haystack_count = haystack_count;
-            return (0..haystack_count).map(Match::from_index).collect();
+            return (0..self.haystacks.len()).map(Match::from_index).collect();
         }
 
-        if haystack_count == self.prev_haystack_count && !self.prev_needle.is_empty() {
-            let level = self.find_reusable_level(needle);
-            if level > 0 {
-                self.restore_or_save(needle, level);
-                let mut matches = self.match_narrowed_unsorted(haystacks);
-                self.save_to_history(needle.len());
-                if self.matcher.config.sort {
-                    matches.sort_unstable();
-                }
-                self.set_prev(needle, haystack_count);
-                return matches;
-            }
-        } else if self.is_prefix_extension(needle) && haystack_count > self.prev_haystack_count {
-            let matches = self.match_narrowed_with_growth(haystacks);
-            self.index_history.clear();
-            self.set_prev(needle, haystack_count);
-            return matches;
+        // Never matched or no needle overlap, start from scratch
+        if self.active_matches.is_none() || reusable_level == 0 {
+            let mut matches = self.matcher.match_list(self.haystacks);
+            self.active_matches = Some(matches.clone());
+            radix_sort(&mut matches);
+            matches
         }
-
-        self.index_history.clear();
-        let result = self.full_rescore(haystacks, needle, haystack_count);
-        self.save_to_history(needle.len());
-        result
-    }
-
-    pub fn match_list_indices<S: AsRef<str>>(
-        &mut self,
-        needle: &str,
-        haystacks: &[S],
-    ) -> Vec<MatchIndices> {
-        let haystack_count = haystacks.len();
-        self.matcher.set_needle(needle);
-
-        if needle.is_empty() {
-            self.reset();
-            self.prev_haystack_count = haystack_count;
-            return (0..haystack_count).map(MatchIndices::from_index).collect();
+        // same needle as last time, return existing matches
+        else if prev_needle == needle {
+            self.active_matches.as_ref().unwrap().clone()
         }
+        // extended the needle with N new characters
+        else if is_prefix_extension {
+            let active_matches = self.active_matches.as_ref().unwrap();
+            let mut matches = self
+                .matcher
+                .match_indexed_list(self.haystacks, active_matches.iter().map(|m| m.index));
+            self.active_matches = Some(matches.clone());
 
-        if haystack_count == self.prev_haystack_count && !self.prev_needle.is_empty() {
-            let level = self.find_reusable_level(needle);
-            if level > 0 {
-                self.restore_or_save(needle, level);
-                let mut matches = self.match_narrowed_indices_unsorted(haystacks);
-                self.save_to_history(needle.len());
-                if self.matcher.config.sort {
-                    matches.sort_unstable();
-                }
-                self.set_prev(needle, haystack_count);
-                return matches;
-            }
-        } else if self.is_prefix_extension(needle) && haystack_count > self.prev_haystack_count {
-            let matches = self.match_narrowed_indices_with_growth(haystacks);
-            self.index_history.clear();
-            self.set_prev(needle, haystack_count);
-            return matches;
+            radix_sort(&mut matches);
+            matches
+        } else {
+            todo!("backspace not supported yet")
         }
-
-        self.index_history.clear();
-        let result = self.full_rescore_indices(haystacks, needle, haystack_count);
-        self.save_to_history(needle.len());
-        result
-    }
-
-    pub fn match_list_parallel<S: AsRef<str> + Sync>(
-        &mut self,
-        needle: &str,
-        haystacks: &[S],
-        threads: usize,
-    ) -> Vec<Match> {
-        let haystack_count = haystacks.len();
-        self.matcher.set_needle(needle);
-
-        if needle.is_empty() {
-            self.reset();
-            self.prev_haystack_count = haystack_count;
-            return (0..haystack_count).map(Match::from_index).collect();
-        }
-
-        if haystack_count == self.prev_haystack_count && !self.prev_needle.is_empty() {
-            let level = self.find_reusable_level(needle);
-            if level > 0 {
-                self.restore_or_save(needle, level);
-                let matches = self.match_narrowed_parallel(haystacks, threads);
-                self.save_to_history(needle.len());
-                self.set_prev(needle, haystack_count);
-                return matches;
-            }
-        } else if self.is_prefix_extension(needle) && haystack_count > self.prev_haystack_count {
-            let matches = self.match_narrowed_parallel(haystacks, threads);
-            self.index_history.clear();
-            self.set_prev(needle, haystack_count);
-            return matches;
-        }
-
-        self.index_history.clear();
-        let matches = self.full_rescore_parallel(haystacks, threads);
-        self.update_state_from_matches(needle, haystack_count, matches.iter().map(|m| m.index));
-        self.save_to_history(needle.len());
-        matches
     }
 
     pub fn reset(&mut self) {
-        self.prev_needle.clear();
-        self.matched_indices.clear();
-        self.prev_haystack_count = 0;
-        self.index_history.clear();
-    }
-
-    pub fn matcher(&self) -> &Matcher {
-        &self.matcher
+        self.removed_idxs.clear();
+        self.active_matches = None;
     }
 
     #[inline(always)]
-    fn is_prefix_extension(&self, needle: &str) -> bool {
-        !self.prev_needle.is_empty()
-            && needle.len() > self.prev_needle.len()
-            && needle.starts_with(&self.prev_needle)
+    fn is_prefix_extension(&self, needle: &str, prev_needle: &str) -> bool {
+        !prev_needle.is_empty()
+            && needle.len() > prev_needle.len()
+            && needle.starts_with(prev_needle)
     }
 
-    fn find_reusable_level(&self, needle: &str) -> usize {
-        if needle.starts_with(&self.prev_needle) {
-            return self.prev_needle.len();
+    fn find_reusable_level(&self, needle: &str, prev_needle: &str) -> usize {
+        if needle.starts_with(prev_needle) {
+            return prev_needle.len();
         }
-        let common = common_prefix_len(needle, &self.prev_needle);
-        for level in (1..=common).rev() {
-            if level <= self.index_history.len() && self.index_history[level - 1].is_some() {
-                return level;
-            }
-        }
-        0
+        Self::common_prefix_len(needle, prev_needle)
     }
 
-    fn restore_or_save(&mut self, needle: &str, level: usize) {
-        if level == self.prev_needle.len() && needle.starts_with(&self.prev_needle) {
-            self.save_to_history(level);
-        } else {
-            self.matched_indices = self.index_history[level - 1].clone().unwrap();
-            self.index_history.truncate(level);
-        }
-    }
-
-    fn save_to_history(&mut self, needle_len: usize) {
-        if needle_len == 0 {
-            return;
-        }
-        let idx = needle_len - 1;
-        if self.index_history.len() <= idx {
-            self.index_history.resize_with(idx + 1, || None);
-        }
-        self.index_history[idx] = Some(self.matched_indices.clone());
-    }
-
-    #[inline]
-    fn set_prev(&mut self, needle: &str, haystack_count: usize) {
-        self.prev_needle.clear();
-        self.prev_needle.push_str(needle);
-        self.prev_haystack_count = haystack_count;
-    }
-
-    #[inline]
-    fn update_state_from_matches(
-        &mut self,
-        needle: &str,
-        haystack_count: usize,
-        indices: impl Iterator<Item = u32>,
-    ) {
-        self.prev_needle.clear();
-        self.prev_needle.push_str(needle);
-        self.matched_indices.clear();
-        self.matched_indices.extend(indices);
-        self.matched_indices.sort_unstable();
-        self.prev_haystack_count = haystack_count;
-    }
-
-    #[inline]
-    fn full_rescore<S: AsRef<str>>(
-        &mut self,
-        haystacks: &[S],
-        needle: &str,
-        haystack_count: usize,
-    ) -> Vec<Match> {
-        let mut matches = Vec::new();
-        self.matcher.match_list_into(haystacks, 0, &mut matches);
-
-        self.matched_indices.clear();
-        self.matched_indices.extend(matches.iter().map(|m| m.index));
-
-        if self.matcher.config.sort {
-            matches.sort_unstable();
-        }
-
-        self.set_prev(needle, haystack_count);
-        matches
-    }
-
-    #[inline]
-    fn full_rescore_indices<S: AsRef<str>>(
-        &mut self,
-        haystacks: &[S],
-        needle: &str,
-        haystack_count: usize,
-    ) -> Vec<MatchIndices> {
-        let mut matches = Vec::new();
-        self.matcher
-            .match_list_indices_into(haystacks, 0, &mut matches);
-
-        self.matched_indices.clear();
-        self.matched_indices.extend(matches.iter().map(|m| m.index));
-
-        if self.matcher.config.sort {
-            matches.sort_unstable();
-        }
-
-        self.set_prev(needle, haystack_count);
-        matches
-    }
-
-    #[inline]
-    fn match_narrowed_unsorted<S: AsRef<str>>(&mut self, haystacks: &[S]) -> Vec<Match> {
-        let mut matches = Vec::with_capacity(self.matched_indices.len());
-
-        let mut write = 0usize;
-        for read in 0..self.matched_indices.len() {
-            let idx = self.matched_indices[read];
-            let haystack = haystacks[idx as usize].as_ref().as_bytes();
-
-            if let Some(m) = self.matcher.match_one(haystack, idx) {
-                self.matched_indices[write] = idx;
-                write += 1;
-                matches.push(m);
-            }
-        }
-        self.matched_indices.truncate(write);
-
-        matches
-    }
-
-    fn match_narrowed_with_growth<S: AsRef<str>>(&mut self, haystacks: &[S]) -> Vec<Match> {
-        let mut matches = self.match_narrowed_unsorted(haystacks);
-
-        let prev_count = self.prev_haystack_count;
-        let matches_before_tail = matches.len();
-        self.matcher
-            .match_list_into(&haystacks[prev_count..], prev_count as u32, &mut matches);
-        self.matched_indices
-            .extend(matches[matches_before_tail..].iter().map(|m| m.index));
-
-        if self.matcher.config.sort {
-            matches.sort_unstable();
-        }
-
-        matches
-    }
-
-    #[inline]
-    fn match_narrowed_indices_unsorted<S: AsRef<str>>(
-        &mut self,
-        haystacks: &[S],
-    ) -> Vec<MatchIndices> {
-        let mut matches = Vec::with_capacity(self.matched_indices.len());
-
-        let mut write = 0usize;
-        for read in 0..self.matched_indices.len() {
-            let idx = self.matched_indices[read];
-            let haystack = haystacks[idx as usize].as_ref().as_bytes();
-
-            if let Some(m) = self.matcher.match_indices_one(haystack, idx) {
-                self.matched_indices[write] = idx;
-                write += 1;
-                matches.push(m);
-            }
-        }
-        self.matched_indices.truncate(write);
-
-        matches
-    }
-
-    fn match_narrowed_indices_with_growth<S: AsRef<str>>(
-        &mut self,
-        haystacks: &[S],
-    ) -> Vec<MatchIndices> {
-        let mut matches = self.match_narrowed_indices_unsorted(haystacks);
-
-        let prev_count = self.prev_haystack_count;
-        let matches_before_tail = matches.len();
-        self.matcher.match_list_indices_into(
-            &haystacks[prev_count..],
-            prev_count as u32,
-            &mut matches,
-        );
-        self.matched_indices
-            .extend(matches[matches_before_tail..].iter().map(|m| m.index));
-
-        if self.matcher.config.sort {
-            matches.sort_unstable();
-        }
-
-        matches
-    }
-
-    fn full_rescore_parallel<S: AsRef<str> + Sync>(
-        &self,
-        haystacks: &[S],
-        threads: usize,
-    ) -> Vec<Match> {
-        if haystacks.is_empty() {
-            return vec![];
-        }
-
-        let chunk_size = 512;
-        let num_chunks = haystacks.len().div_ceil(chunk_size);
-        let next_chunk = AtomicUsize::new(0);
-        let matcher = &self.matcher;
-        let config = &matcher.config;
-
-        thread::scope(|s| {
-            let handles: Vec<_> = (0..threads)
-                .map(|_| {
-                    s.spawn(|| {
-                        let mut local_matches = Vec::new();
-                        let mut thread_matcher = matcher.clone();
-
-                        loop {
-                            let chunk_idx = next_chunk.fetch_add(1, Ordering::Relaxed);
-                            if chunk_idx >= num_chunks {
-                                break;
-                            }
-
-                            let start = chunk_idx * chunk_size;
-                            let end = (start + chunk_size).min(haystacks.len());
-
-                            thread_matcher.match_list_into(
-                                &haystacks[start..end],
-                                start as u32,
-                                &mut local_matches,
-                            );
-                        }
-
-                        if config.sort {
-                            local_matches.sort_unstable();
-                        }
-
-                        local_matches
-                    })
-                })
-                .collect();
-
-            if config.sort {
-                k_merge(
-                    handles
-                        .into_iter()
-                        .map(|h| h.join().unwrap())
-                        .collect::<Vec<_>>(),
-                )
-            } else {
-                handles
-                    .into_iter()
-                    .flat_map(|h| h.join().unwrap())
-                    .collect()
-            }
-        })
-    }
-
-    fn match_narrowed_parallel<S: AsRef<str> + Sync>(
-        &mut self,
-        haystacks: &[S],
-        threads: usize,
-    ) -> Vec<Match> {
-        let mut new_tail_matches = Vec::new();
-        let mut new_tail_indices = Vec::new();
-        if haystacks.len() > self.prev_haystack_count {
-            let prev_count = self.prev_haystack_count;
-            self.matcher.match_list_into(
-                &haystacks[prev_count..],
-                prev_count as u32,
-                &mut new_tail_matches,
-            );
-            new_tail_indices.extend(new_tail_matches.iter().map(|m| m.index));
-        }
-
-        if self.matched_indices.is_empty() {
-            self.matched_indices = new_tail_indices;
-            if self.matcher.config.sort {
-                new_tail_matches.sort_unstable();
-            }
-            return new_tail_matches;
-        }
-
-        let chunk_size = 512;
-        let num_chunks = self.matched_indices.len().div_ceil(chunk_size);
-        let next_chunk = AtomicUsize::new(0);
-
-        let matched_indices = &self.matched_indices;
-        let matcher = &self.matcher;
-        let config = &matcher.config;
-
-        let (thread_matches, new_indices) = thread::scope(|s| {
-            let handles: Vec<_> = (0..threads)
-                .map(|_| {
-                    s.spawn(|| {
-                        let mut local_matches = Vec::new();
-                        let mut local_indices = Vec::new();
-                        let mut thread_matcher = matcher.clone();
-
-                        loop {
-                            let chunk_idx = next_chunk.fetch_add(1, Ordering::Relaxed);
-                            if chunk_idx >= num_chunks {
-                                break;
-                            }
-
-                            let start = chunk_idx * chunk_size;
-                            let end = (start + chunk_size).min(matched_indices.len());
-
-                            for &idx in &matched_indices[start..end] {
-                                let haystack = haystacks[idx as usize].as_ref().as_bytes();
-
-                                if let Some(m) = thread_matcher.match_one(haystack, idx) {
-                                    local_matches.push(m);
-                                    local_indices.push(idx);
-                                }
-                            }
-                        }
-
-                        if config.sort {
-                            local_matches.sort_unstable();
-                        }
-
-                        (local_matches, local_indices)
-                    })
-                })
-                .collect();
-
-            let mut all_indices = Vec::new();
-            let thread_matches = if config.sort {
-                let mut match_vecs = Vec::with_capacity(handles.len());
-                for h in handles {
-                    let (matches, indices) = h.join().unwrap();
-                    all_indices.extend(indices);
-                    match_vecs.push(matches);
-                }
-                k_merge(match_vecs)
-            } else {
-                let mut all_matches = Vec::new();
-                for h in handles {
-                    let (matches, indices) = h.join().unwrap();
-                    all_indices.extend(indices);
-                    all_matches.extend(matches);
-                }
-                all_matches
-            };
-            (thread_matches, all_indices)
-        });
-
-        self.matched_indices = new_indices;
-        self.matched_indices.sort_unstable();
-        self.matched_indices.extend(new_tail_indices);
-
-        if new_tail_matches.is_empty() {
-            thread_matches
-        } else if config.sort {
-            k_merge(vec![thread_matches, new_tail_matches])
-        } else {
-            let mut result = thread_matches;
-            result.extend(new_tail_matches);
-            result
-        }
+    fn common_prefix_len(a: &str, b: &str) -> usize {
+        a.bytes().zip(b.bytes()).take_while(|(x, y)| x == y).count()
     }
 }
 
@@ -534,10 +113,14 @@ mod tests {
     use super::*;
     use crate::match_list;
 
+    fn to_owned_strs(haystacks: &[&str]) -> Vec<String> {
+        haystacks.iter().map(|s| s.to_string()).collect()
+    }
+
     fn assert_match_parity(needle: &str, haystacks: &[&str], config: &Config) {
         let expected = match_list(needle, haystacks, config);
-        let mut incr = IncrementalMatcher::new(config);
-        let actual = incr.match_list(needle, haystacks);
+        let mut incr = IncrementalMatcher::new(config, haystacks);
+        let actual = incr.match_list(needle);
         assert_eq!(
             actual, expected,
             "mismatch for needle {:?}: actual={:?}, expected={:?}",
@@ -551,11 +134,11 @@ mod tests {
             "fooBar", "foo_bar", "prelude", "println!", "fizzBuzz", "format!",
         ];
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
         for needle in ["f", "fo", "foo", "fooB", "fooBar"] {
             let expected = match_list(needle, &haystacks, &config);
-            let actual = incr.match_list(needle, &haystacks);
+            let actual = incr.match_list(needle);
             assert_eq!(actual, expected, "mismatch for needle {:?}", needle);
         }
     }
@@ -564,15 +147,15 @@ mod tests {
     fn prefix_extension_narrows() {
         let haystacks = ["fooBar", "foo_bar", "prelude", "println!", "format!"];
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
-        let m1 = incr.match_list("f", &haystacks);
+        let m1 = incr.match_list("f");
         assert!(!m1.is_empty());
 
-        let m2 = incr.match_list("fo", &haystacks);
+        let m2 = incr.match_list("fo");
         assert!(m2.len() <= m1.len());
 
-        let m3 = incr.match_list("foo", &haystacks);
+        let m3 = incr.match_list("foo");
         assert!(m3.len() <= m2.len());
 
         for needle in ["f", "fo", "foo"] {
@@ -584,10 +167,10 @@ mod tests {
     fn non_prefix_change_full_rescore() {
         let haystacks = ["fooBar", "barBaz", "bazQux"];
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
-        let m1 = incr.match_list("foo", &haystacks);
-        let m2 = incr.match_list("bar", &haystacks);
+        let m1 = incr.match_list("foo");
+        let m2 = incr.match_list("bar");
 
         let expected = match_list("bar", &haystacks, &config);
         assert_eq!(m2, expected);
@@ -601,19 +184,19 @@ mod tests {
     fn backspace_uses_history() {
         let haystacks = ["fooBar", "foo_bar", "fBaz", "format!", "prelude"];
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
         for needle in ["f", "fo", "foo"] {
             let expected = match_list(needle, &haystacks, &config);
-            let actual = incr.match_list(needle, &haystacks);
+            let actual = incr.match_list(needle);
             assert_eq!(actual, expected, "forward mismatch for {:?}", needle);
         }
 
-        let m = incr.match_list("fo", &haystacks);
+        let m = incr.match_list("fo");
         let expected = match_list("fo", &haystacks, &config);
         assert_eq!(m, expected);
 
-        let m = incr.match_list("f", &haystacks);
+        let m = incr.match_list("f");
         let expected = match_list("f", &haystacks, &config);
         assert_eq!(m, expected);
     }
@@ -622,13 +205,13 @@ mod tests {
     fn backspace_then_retype() {
         let haystacks = ["fooBar", "fobBaz", "format!", "prelude"];
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
-        incr.match_list("f", &haystacks);
-        incr.match_list("fo", &haystacks);
-        incr.match_list("foo", &haystacks);
+        incr.match_list("f");
+        incr.match_list("fo");
+        incr.match_list("foo");
 
-        let m = incr.match_list("fob", &haystacks);
+        let m = incr.match_list("fob");
         let expected = match_list("fob", &haystacks, &config);
         assert_eq!(m, expected);
     }
@@ -637,17 +220,17 @@ mod tests {
     fn multi_backspace() {
         let haystacks = ["fooBarBaz", "fooBat", "fooXyz", "prelude"];
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
         for needle in ["f", "fo", "foo", "fooB", "fooBar"] {
-            incr.match_list(needle, &haystacks);
+            incr.match_list(needle);
         }
 
-        let m = incr.match_list("fo", &haystacks);
+        let m = incr.match_list("fo");
         let expected = match_list("fo", &haystacks, &config);
         assert_eq!(m, expected);
 
-        let m = incr.match_list("foo", &haystacks);
+        let m = incr.match_list("foo");
         let expected = match_list("foo", &haystacks, &config);
         assert_eq!(m, expected);
     }
@@ -656,39 +239,39 @@ mod tests {
     fn empty_needle_returns_all() {
         let haystacks = ["foo", "bar", "baz"];
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
-        let m = incr.match_list("", &haystacks);
+        let m = incr.match_list("");
         assert_eq!(m.len(), 3);
         for m in &m {
             assert_eq!(m.score, 0);
         }
     }
 
-    #[test]
-    fn haystack_growth() {
-        let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
-
-        let haystacks_small: Vec<&str> = vec!["fooBar", "foo_bar", "prelude"];
-        incr.match_list("f", &haystacks_small);
-
-        let haystacks_big: Vec<&str> = vec!["fooBar", "foo_bar", "prelude", "format!", "fizz"];
-        let m2 = incr.match_list("fo", &haystacks_big);
-
-        let expected = match_list("fo", &haystacks_big, &config);
-        assert_eq!(m2, expected);
-    }
+    // #[test]
+    // fn haystack_growth() {
+    //     let config = Config::default();
+    //     let mut incr = IncrementalMatcher::new(&config);
+    //
+    //     let haystacks_small: Vec<&str> = vec!["fooBar", "foo_bar", "prelude"];
+    //     incr.match_list("f", &haystacks_small);
+    //
+    //     let haystacks_big: Vec<&str> = vec!["fooBar", "foo_bar", "prelude", "format!", "fizz"];
+    //     let m2 = incr.match_list("fo", &haystacks_big);
+    //
+    //     let expected = match_list("fo", &haystacks_big, &config);
+    //     assert_eq!(m2, expected);
+    // }
 
     #[test]
     fn reset_forces_full_rescore() {
         let haystacks = ["fooBar", "foo_bar"];
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
-        incr.match_list("f", &haystacks);
+        incr.match_list("f");
         incr.reset();
-        let m = incr.match_list("fo", &haystacks);
+        let m = incr.match_list("fo");
         let expected = match_list("fo", &haystacks, &config);
         assert_eq!(m, expected);
     }
@@ -700,11 +283,11 @@ mod tests {
             max_typos: None,
             ..Config::default()
         };
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
         for needle in ["f", "fo", "foo", "fooB"] {
             let expected = match_list(needle, &haystacks, &config);
-            let actual = incr.match_list(needle, &haystacks);
+            let actual = incr.match_list(needle);
             assert_eq!(actual, expected, "mismatch for needle {:?}", needle);
         }
     }
@@ -716,11 +299,11 @@ mod tests {
             max_typos: Some(1),
             ..Config::default()
         };
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
         for needle in ["f", "fo", "foo", "fooB"] {
             let expected = match_list(needle, &haystacks, &config);
-            let actual = incr.match_list(needle, &haystacks);
+            let actual = incr.match_list(needle);
             assert_eq!(actual, expected, "mismatch for needle {:?}", needle);
         }
     }
@@ -733,11 +316,11 @@ mod tests {
 
         let refs: Vec<&str> = haystacks.iter().map(|s| s.as_str()).collect();
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &refs);
 
         for needle in ["f", "fo", "foo", "fooB", "fooBar"] {
             let expected = match_list(needle, &refs, &config);
-            let actual = incr.match_list(needle, &refs);
+            let actual = incr.match_list(needle);
             assert_eq!(actual, expected, "mismatch for needle {:?}", needle);
         }
     }
@@ -747,59 +330,12 @@ mod tests {
         let haystacks: Vec<String> = (0..100).map(|i| format!("foo_{}", i)).collect();
         let refs: Vec<&str> = haystacks.iter().map(|s| s.as_str()).collect();
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &refs);
 
         for needle in ["f", "fo", "foo", "foo_"] {
             let expected = match_list(needle, &refs, &config);
-            let actual = incr.match_list(needle, &refs);
+            let actual = incr.match_list(needle);
             assert_eq!(actual, expected, "mismatch for needle {:?}", needle);
-        }
-    }
-
-    #[test]
-    fn match_list_indices_parity() {
-        let haystacks = ["fooBar", "foo_bar", "prelude", "println!"];
-        let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
-
-        for needle in ["f", "fo", "foo", "fooB"] {
-            let expected = crate::match_list_indices(needle, &haystacks, &config);
-            let actual = incr.match_list_indices(needle, &haystacks);
-            assert_eq!(
-                actual.len(),
-                expected.len(),
-                "length mismatch for needle {:?}",
-                needle
-            );
-            for (a, e) in actual.iter().zip(expected.iter()) {
-                assert_eq!(a.index, e.index, "index mismatch for needle {:?}", needle);
-                assert_eq!(a.score, e.score, "score mismatch for needle {:?}", needle);
-                assert_eq!(a.exact, e.exact, "exact mismatch for needle {:?}", needle);
-                assert_eq!(
-                    a.indices, e.indices,
-                    "indices mismatch for needle {:?}",
-                    needle
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn parallel_parity() {
-        let haystacks = [
-            "fooBar", "foo_bar", "prelude", "println!", "format!", "fizzBuzz",
-        ];
-        let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
-
-        for needle in ["f", "fo", "foo", "fooB"] {
-            let expected = match_list(needle, &haystacks, &config);
-            let actual = incr.match_list_parallel(needle, &haystacks, 2);
-            assert_eq!(
-                actual, expected,
-                "parallel mismatch for needle {:?}",
-                needle
-            );
         }
     }
 
@@ -807,10 +343,10 @@ mod tests {
     fn same_needle_full_rescore() {
         let haystacks = ["fooBar", "foo_bar"];
         let config = Config::default();
-        let mut incr = IncrementalMatcher::new(&config);
+        let mut incr = IncrementalMatcher::new(&config, &haystacks);
 
-        let first = incr.match_list("foo", &haystacks);
-        let second = incr.match_list("foo", &haystacks);
+        let first = incr.match_list("foo");
+        let second = incr.match_list("foo");
         assert_eq!(first, second);
     }
 }

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -1,7 +1,7 @@
-use itertools::Itertools;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
+use crate::k_merge::k_merge;
 use crate::one_shot::Matcher;
 use crate::{Config, Match, MatchIndices};
 
@@ -280,34 +280,13 @@ impl IncrementalMatcher {
     #[inline]
     fn match_narrowed_unsorted<S: AsRef<str>>(&mut self, haystacks: &[S]) -> Vec<Match> {
         let mut matches = Vec::with_capacity(self.matched_indices.len());
-        let max_typos = self.matcher.config.max_typos;
-        let needle_len = self.matcher.needle.len();
-        let min_haystack_len = max_typos
-            .map(|max| needle_len.saturating_sub(max as usize))
-            .unwrap_or(0);
 
         let mut write = 0usize;
         for read in 0..self.matched_indices.len() {
             let idx = self.matched_indices[read];
             let haystack = haystacks[idx as usize].as_ref().as_bytes();
 
-            if haystack.len() < min_haystack_len {
-                continue;
-            }
-
-            let (matched, skipped_chunks) = match max_typos {
-                Some(max) => self.matcher.prefilter.match_haystack(haystack, max),
-                None => (true, 0),
-            };
-            if !matched {
-                continue;
-            }
-
-            let trimmed = &haystack[skipped_chunks * 16..];
-            if let Some(m) =
-                self.matcher
-                    .smith_waterman_one(trimmed, idx, skipped_chunks == 0)
-            {
+            if let Some(m) = self.matcher.match_one(haystack, idx) {
                 self.matched_indices[write] = idx;
                 write += 1;
                 matches.push(m);
@@ -341,36 +320,13 @@ impl IncrementalMatcher {
         haystacks: &[S],
     ) -> Vec<MatchIndices> {
         let mut matches = Vec::with_capacity(self.matched_indices.len());
-        let max_typos = self.matcher.config.max_typos;
-        let needle_len = self.matcher.needle.len();
-        let min_haystack_len = max_typos
-            .map(|max| needle_len.saturating_sub(max as usize))
-            .unwrap_or(0);
 
         let mut write = 0usize;
         for read in 0..self.matched_indices.len() {
             let idx = self.matched_indices[read];
             let haystack = haystacks[idx as usize].as_ref().as_bytes();
 
-            if haystack.len() < min_haystack_len {
-                continue;
-            }
-
-            let (matched, skipped_chunks) = match max_typos {
-                Some(max) => self.matcher.prefilter.match_haystack(haystack, max),
-                None => (true, 0),
-            };
-            if !matched {
-                continue;
-            }
-
-            let trimmed = &haystack[skipped_chunks * 16..];
-            if let Some(m) = self.matcher.smith_waterman_indices_one(
-                trimmed,
-                skipped_chunks,
-                idx,
-                skipped_chunks == 0,
-            ) {
+            if let Some(m) = self.matcher.match_indices_one(haystack, idx) {
                 self.matched_indices[write] = idx;
                 write += 1;
                 matches.push(m);
@@ -389,8 +345,11 @@ impl IncrementalMatcher {
 
         let prev_count = self.prev_haystack_count;
         let matches_before_tail = matches.len();
-        self.matcher
-            .match_list_indices_into(&haystacks[prev_count..], prev_count as u32, &mut matches);
+        self.matcher.match_list_indices_into(
+            &haystacks[prev_count..],
+            prev_count as u32,
+            &mut matches,
+        );
         self.matched_indices
             .extend(matches[matches_before_tail..].iter().map(|m| m.index));
 
@@ -449,11 +408,12 @@ impl IncrementalMatcher {
                 .collect();
 
             if config.sort {
-                handles
-                    .into_iter()
-                    .map(|h| h.join().unwrap())
-                    .kmerge()
-                    .collect()
+                k_merge(
+                    handles
+                        .into_iter()
+                        .map(|h| h.join().unwrap())
+                        .collect::<Vec<_>>(),
+                )
             } else {
                 handles
                     .into_iter()
@@ -495,11 +455,6 @@ impl IncrementalMatcher {
         let matched_indices = &self.matched_indices;
         let matcher = &self.matcher;
         let config = &matcher.config;
-        let max_typos = config.max_typos;
-        let needle_len = matcher.needle.len();
-        let min_haystack_len = max_typos
-            .map(|max| needle_len.saturating_sub(max as usize))
-            .unwrap_or(0);
 
         let (thread_matches, new_indices) = thread::scope(|s| {
             let handles: Vec<_> = (0..threads)
@@ -521,26 +476,7 @@ impl IncrementalMatcher {
                             for &idx in &matched_indices[start..end] {
                                 let haystack = haystacks[idx as usize].as_ref().as_bytes();
 
-                                if haystack.len() < min_haystack_len {
-                                    continue;
-                                }
-
-                                let (matched, skipped_chunks) = match max_typos {
-                                    Some(max) => {
-                                        thread_matcher.prefilter.match_haystack(haystack, max)
-                                    }
-                                    None => (true, 0),
-                                };
-                                if !matched {
-                                    continue;
-                                }
-
-                                let trimmed = &haystack[skipped_chunks * 16..];
-                                if let Some(m) = thread_matcher.smith_waterman_one(
-                                    trimmed,
-                                    idx,
-                                    skipped_chunks == 0,
-                                ) {
+                                if let Some(m) = thread_matcher.match_one(haystack, idx) {
                                     local_matches.push(m);
                                     local_indices.push(idx);
                                 }
@@ -564,7 +500,7 @@ impl IncrementalMatcher {
                     all_indices.extend(indices);
                     match_vecs.push(matches);
                 }
-                match_vecs.into_iter().kmerge().collect::<Vec<Match>>()
+                k_merge(match_vecs)
             } else {
                 let mut all_matches = Vec::new();
                 for h in handles {
@@ -584,10 +520,7 @@ impl IncrementalMatcher {
         if new_tail_matches.is_empty() {
             thread_matches
         } else if config.sort {
-            thread_matches
-                .into_iter()
-                .merge(new_tail_matches)
-                .collect()
+            k_merge(vec![thread_matches, new_tail_matches])
         } else {
             let mut result = thread_matches;
             result.extend(new_tail_matches);
@@ -615,12 +548,7 @@ mod tests {
     #[test]
     fn incremental_matches_one_shot() {
         let haystacks = [
-            "fooBar",
-            "foo_bar",
-            "prelude",
-            "println!",
-            "fizzBuzz",
-            "format!",
+            "fooBar", "foo_bar", "prelude", "println!", "fizzBuzz", "format!",
         ];
         let config = Config::default();
         let mut incr = IncrementalMatcher::new(&config);
@@ -867,7 +795,11 @@ mod tests {
         for needle in ["f", "fo", "foo", "fooB"] {
             let expected = match_list(needle, &haystacks, &config);
             let actual = incr.match_list_parallel(needle, &haystacks, 2);
-            assert_eq!(actual, expected, "parallel mismatch for needle {:?}", needle);
+            assert_eq!(
+                actual, expected,
+                "parallel mismatch for needle {:?}",
+                needle
+            );
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,12 +43,14 @@ use std::cmp::Ordering;
 use serde::{Deserialize, Serialize};
 
 mod r#const;
+mod incremental;
 mod k_merge;
 mod one_shot;
 mod prefilter;
 mod smith_waterman;
 pub mod sort;
 
+pub use incremental::IncrementalMatcher;
 pub use k_merge::k_merge;
 pub use one_shot::{Matcher, match_list, match_list_indices, match_list_parallel};
 pub use sort::radix_sort;

--- a/src/one_shot/matcher/algo.rs
+++ b/src/one_shot/matcher/algo.rs
@@ -96,6 +96,70 @@ where
     }
 
     #[inline(always)]
+    pub fn match_indexed_list_impl<H: AsRef<str>>(
+        &mut self,
+        haystacks: &[H],
+        indices: impl Iterator<Item = u32>,
+    ) -> Vec<Match> {
+        let mut matches = vec![];
+        self.match_indexed_list_into_impl(haystacks, indices, &mut matches);
+        matches
+    }
+
+    #[inline(always)]
+    pub fn match_indexed_list_into_impl<H: AsRef<str>>(
+        &mut self,
+        haystacks: &[H],
+        indices: impl Iterator<Item = u32>,
+        matches: &mut Vec<Match>,
+    ) {
+        Matcher::guard_against_haystack_overflow(haystacks.len(), 0);
+        if self.needle.is_empty() {
+            return matches.extend(indices.map(|index| Match::from_index(index as usize)));
+        }
+
+        let max_typos = self.config.max_typos;
+        let min_haystack_len = self.min_haystack_len();
+        match max_typos {
+            None => self.match_indexed_list_prefiltered_into::<0, H>(
+                haystacks,
+                indices,
+                min_haystack_len,
+                0,
+                matches,
+            ),
+            Some(0) => self.match_indexed_list_prefiltered_into::<0, H>(
+                haystacks,
+                indices,
+                min_haystack_len,
+                0,
+                matches,
+            ),
+            Some(1) => self.match_indexed_list_prefiltered_into::<1, H>(
+                haystacks,
+                indices,
+                min_haystack_len,
+                1,
+                matches,
+            ),
+            Some(2) => self.match_indexed_list_prefiltered_into::<2, H>(
+                haystacks,
+                indices,
+                min_haystack_len,
+                2,
+                matches,
+            ),
+            Some(max_typos) => self.match_indexed_list_prefiltered_into::<MANY_TYPOS, H>(
+                haystacks,
+                indices,
+                min_haystack_len,
+                max_typos,
+                matches,
+            ),
+        }
+    }
+
+    #[inline(always)]
     pub fn match_list_indices_impl<H: AsRef<str>>(&mut self, haystacks: &[H]) -> Vec<MatchIndices> {
         Matcher::guard_against_haystack_overflow(haystacks.len(), 0);
         if self.needle.is_empty() {
@@ -120,48 +184,6 @@ where
         }
 
         matches
-    }
-
-    #[inline(always)]
-    pub fn match_one_impl(&mut self, haystack: &[u8], index: u32) -> Option<Match> {
-        if self.needle.is_empty() {
-            return Some(Match::from_index(index as usize));
-        }
-
-        let original_len = haystack.len();
-        if original_len < self.min_haystack_len() {
-            return None;
-        }
-
-        match self.config.max_typos {
-            None => Some(self.smith_waterman_one(haystack, index, 0, true)),
-            Some(0) => self.match_one_prefiltered::<0>(haystack, index, 0),
-            Some(1) => self.match_one_prefiltered::<1>(haystack, index, 1),
-            Some(2) => self.match_one_prefiltered::<2>(haystack, index, 2),
-            Some(max_typos) => self.match_one_prefiltered::<MANY_TYPOS>(haystack, index, max_typos),
-        }
-    }
-
-    #[inline(always)]
-    pub fn match_indices_one_impl(&mut self, haystack: &[u8], index: u32) -> Option<MatchIndices> {
-        if self.needle.is_empty() {
-            return Some(MatchIndices::from_index(index as usize));
-        }
-
-        let original_len = haystack.len();
-        if original_len < self.min_haystack_len() {
-            return None;
-        }
-
-        match self.config.max_typos {
-            None => self.smith_waterman_indices_one(haystack, 0, index, true, None),
-            Some(0) => self.match_indices_one_prefiltered::<0>(haystack, index, 0),
-            Some(1) => self.match_indices_one_prefiltered::<1>(haystack, index, 1),
-            Some(2) => self.match_indices_one_prefiltered::<2>(haystack, index, 2),
-            Some(max_typos) => {
-                self.match_indices_one_prefiltered::<MANY_TYPOS>(haystack, index, max_typos)
-            }
-        }
     }
 
     #[inline(always)]
@@ -210,21 +232,27 @@ where
     }
 
     #[inline(always)]
-    fn match_one_prefiltered<const TYPOS: u16>(
+    fn match_indexed_list_prefiltered_into<const TYPOS: u16, H: AsRef<str>>(
         &mut self,
-        haystack: &[u8],
-        index: u32,
+        haystacks: &[H],
+        indices: impl Iterator<Item = u32>,
+        min_haystack_len: usize,
         max_typos: u16,
-    ) -> Option<Match> {
-        let original_len = haystack.len();
-        let (matched, start_pos, end_pos) = self.prefilter_haystack::<TYPOS>(haystack, max_typos);
-        if !matched {
-            return None;
+        matches: &mut Vec<Match>,
+    ) {
+        for index in indices {
+            let haystack = haystacks[index as usize].as_ref().as_bytes();
+            let original_len = haystack.len();
+            if original_len >= min_haystack_len {
+                let (matched, start_pos, end_pos) =
+                    self.prefilter_haystack::<TYPOS>(haystack, max_typos);
+                if matched {
+                    let trimmed = &haystack[start_pos..end_pos];
+                    let include_exact = start_pos == 0 && end_pos == original_len;
+                    matches.push(self.smith_waterman_one(trimmed, index, start_pos, include_exact));
+                }
+            }
         }
-
-        let trimmed = &haystack[start_pos..end_pos];
-        let include_exact = start_pos == 0 && end_pos == original_len;
-        Some(self.smith_waterman_one(trimmed, index, start_pos, include_exact))
     }
 
     #[inline(always)]
@@ -287,24 +315,6 @@ where
             }
         }
         matches
-    }
-
-    #[inline(always)]
-    fn match_indices_one_prefiltered<const TYPOS: u16>(
-        &mut self,
-        haystack: &[u8],
-        index: u32,
-        max_typos: u16,
-    ) -> Option<MatchIndices> {
-        let original_len = haystack.len();
-        let (matched, start_pos, end_pos) = self.prefilter_haystack::<TYPOS>(haystack, max_typos);
-        if !matched {
-            return None;
-        }
-
-        let trimmed = &haystack[start_pos..end_pos];
-        let include_exact = start_pos == 0 && end_pos == original_len;
-        self.smith_waterman_indices_one(trimmed, start_pos, index, include_exact, Some(max_typos))
     }
 
     #[inline(always)]

--- a/src/one_shot/matcher/algo.rs
+++ b/src/one_shot/matcher/algo.rs
@@ -123,6 +123,48 @@ where
     }
 
     #[inline(always)]
+    pub fn match_one_impl(&mut self, haystack: &[u8], index: u32) -> Option<Match> {
+        if self.needle.is_empty() {
+            return Some(Match::from_index(index as usize));
+        }
+
+        let original_len = haystack.len();
+        if original_len < self.min_haystack_len() {
+            return None;
+        }
+
+        match self.config.max_typos {
+            None => Some(self.smith_waterman_one(haystack, index, 0, true)),
+            Some(0) => self.match_one_prefiltered::<0>(haystack, index, 0),
+            Some(1) => self.match_one_prefiltered::<1>(haystack, index, 1),
+            Some(2) => self.match_one_prefiltered::<2>(haystack, index, 2),
+            Some(max_typos) => self.match_one_prefiltered::<MANY_TYPOS>(haystack, index, max_typos),
+        }
+    }
+
+    #[inline(always)]
+    pub fn match_indices_one_impl(&mut self, haystack: &[u8], index: u32) -> Option<MatchIndices> {
+        if self.needle.is_empty() {
+            return Some(MatchIndices::from_index(index as usize));
+        }
+
+        let original_len = haystack.len();
+        if original_len < self.min_haystack_len() {
+            return None;
+        }
+
+        match self.config.max_typos {
+            None => self.smith_waterman_indices_one(haystack, 0, index, true, None),
+            Some(0) => self.match_indices_one_prefiltered::<0>(haystack, index, 0),
+            Some(1) => self.match_indices_one_prefiltered::<1>(haystack, index, 1),
+            Some(2) => self.match_indices_one_prefiltered::<2>(haystack, index, 2),
+            Some(max_typos) => {
+                self.match_indices_one_prefiltered::<MANY_TYPOS>(haystack, index, max_typos)
+            }
+        }
+    }
+
+    #[inline(always)]
     fn match_list_unfiltered_into<H: AsRef<str>>(
         &mut self,
         haystacks: &[H],
@@ -165,6 +207,24 @@ where
             }
             index += 1;
         }
+    }
+
+    #[inline(always)]
+    fn match_one_prefiltered<const TYPOS: u16>(
+        &mut self,
+        haystack: &[u8],
+        index: u32,
+        max_typos: u16,
+    ) -> Option<Match> {
+        let original_len = haystack.len();
+        let (matched, start_pos, end_pos) = self.prefilter_haystack::<TYPOS>(haystack, max_typos);
+        if !matched {
+            return None;
+        }
+
+        let trimmed = &haystack[start_pos..end_pos];
+        let include_exact = start_pos == 0 && end_pos == original_len;
+        Some(self.smith_waterman_one(trimmed, index, start_pos, include_exact))
     }
 
     #[inline(always)]
@@ -227,6 +287,24 @@ where
             }
         }
         matches
+    }
+
+    #[inline(always)]
+    fn match_indices_one_prefiltered<const TYPOS: u16>(
+        &mut self,
+        haystack: &[u8],
+        index: u32,
+        max_typos: u16,
+    ) -> Option<MatchIndices> {
+        let original_len = haystack.len();
+        let (matched, start_pos, end_pos) = self.prefilter_haystack::<TYPOS>(haystack, max_typos);
+        if !matched {
+            return None;
+        }
+
+        let trimmed = &haystack[start_pos..end_pos];
+        let include_exact = start_pos == 0 && end_pos == original_len;
+        self.smith_waterman_indices_one(trimmed, start_pos, index, include_exact, Some(max_typos))
     }
 
     #[inline(always)]

--- a/src/one_shot/matcher/backend.rs
+++ b/src/one_shot/matcher/backend.rs
@@ -92,6 +92,22 @@ macro_rules! impl_matcher_entrypoints {
             ) -> Vec<MatchIndices> {
                 self.match_list_indices_impl(haystacks)
             }
+
+            #[inline]
+            $(#[target_feature(enable = $feature)])?
+            pub unsafe fn match_one(&mut self, haystack: &[u8], index: u32) -> Option<Match> {
+                self.match_one_impl(haystack, index)
+            }
+
+            #[inline]
+            $(#[target_feature(enable = $feature)])?
+            pub unsafe fn match_indices_one(
+                &mut self,
+                haystack: &[u8],
+                index: u32,
+            ) -> Option<MatchIndices> {
+                self.match_indices_one_impl(haystack, index)
+            }
         }
     };
 }

--- a/src/one_shot/matcher/backend.rs
+++ b/src/one_shot/matcher/backend.rs
@@ -86,27 +86,32 @@ macro_rules! impl_matcher_entrypoints {
 
             #[inline]
             $(#[target_feature(enable = $feature)])?
+            pub unsafe fn match_indexed_list<S: AsRef<str>>(
+                &mut self,
+                haystacks: &[S],
+                indices: impl Iterator<Item = u32>,
+            ) -> Vec<Match> {
+                self.match_indexed_list_impl(haystacks, indices)
+            }
+
+            #[inline]
+            $(#[target_feature(enable = $feature)])?
+            pub unsafe fn match_indexed_list_into<S: AsRef<str>>(
+                &mut self,
+                haystacks: &[S],
+                indices: impl Iterator<Item = u32>,
+                matches: &mut Vec<Match>,
+            ) {
+                self.match_indexed_list_into_impl(haystacks, indices, matches)
+            }
+
+            #[inline]
+            $(#[target_feature(enable = $feature)])?
             pub unsafe fn match_list_indices<S: AsRef<str>>(
                 &mut self,
                 haystacks: &[S],
             ) -> Vec<MatchIndices> {
                 self.match_list_indices_impl(haystacks)
-            }
-
-            #[inline]
-            $(#[target_feature(enable = $feature)])?
-            pub unsafe fn match_one(&mut self, haystack: &[u8], index: u32) -> Option<Match> {
-                self.match_one_impl(haystack, index)
-            }
-
-            #[inline]
-            $(#[target_feature(enable = $feature)])?
-            pub unsafe fn match_indices_one(
-                &mut self,
-                haystack: &[u8],
-                index: u32,
-            ) -> Option<MatchIndices> {
-                self.match_indices_one_impl(haystack, index)
             }
         }
     };

--- a/src/one_shot/matcher/mod.rs
+++ b/src/one_shot/matcher/mod.rs
@@ -60,11 +60,21 @@ impl Matcher {
         unsafe { dispatch!(&mut self.backend, matcher => matcher.match_list(haystacks)) }
     }
 
+    pub fn match_indexed_list<S: AsRef<str>>(
+        &mut self,
+        haystacks: &[S],
+        indices: impl Iterator<Item = u32>,
+    ) -> Vec<Match> {
+        unsafe {
+            dispatch!(&mut self.backend, matcher => matcher.match_indexed_list(haystacks, indices))
+        }
+    }
+
     pub fn match_list_indices<S: AsRef<str>>(&mut self, haystacks: &[S]) -> Vec<MatchIndices> {
         unsafe { dispatch!(&mut self.backend, matcher => matcher.match_list_indices(haystacks)) }
     }
 
-    pub(crate) fn match_list_into<S: AsRef<str>>(
+    pub fn match_list_into<S: AsRef<str>>(
         &mut self,
         haystacks: &[S],
         haystack_index_offset: u32,
@@ -77,7 +87,20 @@ impl Matcher {
         }
     }
 
-    pub(crate) fn match_list_indices_into<S: AsRef<str>>(
+    pub fn match_indexed_list_into<S: AsRef<str>>(
+        &mut self,
+        haystacks: &[S],
+        indices: impl Iterator<Item = u32>,
+        matches: &mut Vec<Match>,
+    ) {
+        unsafe {
+            dispatch!(&mut self.backend, matcher => {
+                matcher.match_indexed_list_into(haystacks, indices, matches)
+            })
+        }
+    }
+
+    pub fn match_list_indices_into<S: AsRef<str>>(
         &mut self,
         haystacks: &[S],
         haystack_index_offset: u32,
@@ -98,22 +121,6 @@ impl Matcher {
             match_.index += haystack_index_offset;
         }
         matches.extend(new_matches);
-    }
-
-    pub(crate) fn match_one(&mut self, haystack: &[u8], index: u32) -> Option<Match> {
-        unsafe { dispatch!(&mut self.backend, matcher => matcher.match_one(haystack, index)) }
-    }
-
-    pub(crate) fn match_indices_one(
-        &mut self,
-        haystack: &[u8],
-        index: u32,
-    ) -> Option<MatchIndices> {
-        unsafe {
-            dispatch!(&mut self.backend, matcher => {
-                matcher.match_indices_one(haystack, index)
-            })
-        }
     }
 
     #[inline(always)]

--- a/src/one_shot/matcher/mod.rs
+++ b/src/one_shot/matcher/mod.rs
@@ -64,7 +64,7 @@ impl Matcher {
         unsafe { dispatch!(&mut self.backend, matcher => matcher.match_list_indices(haystacks)) }
     }
 
-    pub(super) fn match_list_into<S: AsRef<str>>(
+    pub(crate) fn match_list_into<S: AsRef<str>>(
         &mut self,
         haystacks: &[S],
         haystack_index_offset: u32,
@@ -73,6 +73,45 @@ impl Matcher {
         unsafe {
             dispatch!(&mut self.backend, matcher => {
                 matcher.match_list_into(haystacks, haystack_index_offset, matches)
+            })
+        }
+    }
+
+    pub(crate) fn match_list_indices_into<S: AsRef<str>>(
+        &mut self,
+        haystacks: &[S],
+        haystack_index_offset: u32,
+        matches: &mut Vec<MatchIndices>,
+    ) {
+        Self::guard_against_haystack_overflow(haystacks.len(), haystack_index_offset);
+
+        if self.needle.is_empty() {
+            matches.extend(
+                (0..haystacks.len())
+                    .map(|index| MatchIndices::from_index(index + haystack_index_offset as usize)),
+            );
+            return;
+        }
+
+        let mut new_matches = self.match_list_indices(haystacks);
+        for match_ in &mut new_matches {
+            match_.index += haystack_index_offset;
+        }
+        matches.extend(new_matches);
+    }
+
+    pub(crate) fn match_one(&mut self, haystack: &[u8], index: u32) -> Option<Match> {
+        unsafe { dispatch!(&mut self.backend, matcher => matcher.match_one(haystack, index)) }
+    }
+
+    pub(crate) fn match_indices_one(
+        &mut self,
+        haystack: &[u8],
+        index: u32,
+    ) -> Option<MatchIndices> {
+        unsafe {
+            dispatch!(&mut self.backend, matcher => {
+                matcher.match_indices_one(haystack, index)
             })
         }
     }

--- a/src/smith_waterman/simd/alignment_iter.rs
+++ b/src/smith_waterman/simd/alignment_iter.rs
@@ -111,20 +111,20 @@ impl<'a> Iterator for AlignmentPathIter<'a> {
             return None;
         }
 
-        if let Some(max_typos) = self.max_typos
-            && self.typo_count > max_typos
-        {
-            self.finished = true;
-            return Some(None);
+        if let Some(max_typos) = self.max_typos {
+            if self.typo_count > max_typos {
+                self.finished = true;
+                return Some(None);
+            }
         }
 
         // Must be moving up only (at left edge), or lost alignment
         if self.col_idx < self.lanes_per_chunk || self.score == 0 {
-            if let Some(max_typos) = self.max_typos
-                && (self.typo_count + self.row_idx as u16) > max_typos
-            {
-                self.finished = true;
-                return Some(None);
+            if let Some(max_typos) = self.max_typos {
+                if (self.typo_count + self.row_idx as u16) > max_typos {
+                    self.finished = true;
+                    return Some(None);
+                }
             }
             return None;
         }


### PR DESCRIPTION
Hi @saghen, this is between a draft and fully ready, so feel free to share your opinion. 

*Note: AI was used to help write the benchmark code.*

Closes #5, related to television discussion - [#19](https://github.com/alexpasmantier/television/discussions/19) 

## What this does

When you're typing into a fuzzy finder character by character (`f` -> `fo` -> `foo`), each keystroke can only eliminate matches from the previous set - it can never add new ones. `IncrementalMatcher` takes advantage of this by remembering which haystack indices matched last time and only rescoring that shrinking subset on each prefix extension. Everything else (completely different query, haystack list change) falls back to a full rescore.

The API mirrors `Matcher` but takes the needle per-call instead of at construction:

```rust
let mut matcher = IncrementalMatcher::new(&config);
let matches = matcher.match_list("f", &haystacks);
let matches = matcher.match_list("fo", &haystacks);  // only rescores previous matches
```

Also supports `match_list_indices`, `match_list_parallel`, `reset()`, and handles haystack growth between calls.

Benchmark results on synthetic file-path data (500k haystacks, 8 keystroke sequence):

```
Overall:  one-shot 319ms  incremental 166ms  (1.92x)

Per step:
 "s"        482088 matches    30ms →  30ms   1.0x
 "sr"       355063 matches    44ms →  43ms   1.0x
 "src"      188339 matches    41ms →  36ms   1.2x
 "src/"     112305 matches    43ms →  25ms   1.7x
 "src/c"     53330 matches    50ms →  18ms   2.7x
 "src/co"    42282 matches    51ms →   6ms   8.5x
 "src/com"   17301 matches    38ms →   3ms   9.8x
 "src/comp"   6293 matches    22ms →   1ms  16.2x
```

Early steps where almost everything matches show no overhead (1.0x). The wins kick in once selectivity increases and the narrowed subset gets meaningfully smaller.

## Approaches I tested that didn't pan out

**Delta prefilter** - before running the full SIMD prefilter on the narrowed set, check if just the *new* character exists in the haystack (cheap scalar byte scan). Turns out the SIMD prefilter already runs at ~16ns/item, and the scalar check costs ~25ns/item. Adding it as a pre-pass actually made things slower since the SIMD path is already fast enough that the extra branch isn't worth it.

**Incremental prefilter/SW construction** - `set_needle` rebuilds both the prefilter and the Smith-Waterman matcher from scratch each call. Thought about making it append-only for prefix extensions. Measured it: `set_needle` costs 120-270ns depending on needle length. Over an 8-step sequence that's ~1.7µs total out of ~166ms. Not worth the complexity, and the SW matrix uses a variable stride that changes per haystack, making in-place growth impractical without reworking the core DP.

**Partial SW reuse** - cache the first N-1 rows of the score matrix from the previous needle, only compute the new row. Problem is the matrix is per-haystack (different haystack lengths = different column counts), so you'd need to store a matrix per surviving match. That's ~12KB per match. At 23k matches that's 280MB.

## What could come next

- Top-K mode where you can stop scoring early once you have enough high-quality results. Right now we score everything because the API returns all matches. A `match_list_top_k(needle, haystacks, k)` variant could skip SW for items that can't possibly make the cut based on their previous score.
- Score threshold parameter for similar early-out behavior when the caller knows they only care about matches above a quality bar.
