### PR TITLE
fix: matrix buffer overflow

### DIFF
--- a/src/smith_waterman/simd/matrix.rs
+++ b/src/smith_waterman/simd/matrix.rs
@@ -27,7 +27,7 @@ impl<Simd256: Vector256> Matrix<Simd256> {
             std::ptr::write_bytes(
                 self.matrix.as_mut_ptr(),
                 0,
-                (self.haystack_chunks + 1) * (self.needle_len + 1),
+                self.haystack_chunks * (self.needle_len + 1),
             );
         }
     }
@@ -50,5 +50,76 @@ impl<Simd256: Vector256> Matrix<Simd256> {
     #[inline(always)]
     pub fn as_slice(&self) -> &[[u16; 16]] {
         unsafe { std::mem::transmute::<&[Simd256], &[[u16; 16]]>(&self.matrix) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Proves that `zero()` must not write more elements than were allocated.
+    ///
+    /// Bug pinning: `zero()` used `(haystack_chunks + 1) * (needle_len + 1)`
+    /// but `new()` only allocates `haystack_chunks * (needle_len + 1)`, causing a heap
+    /// buffer overflow of `(needle_len + 1)` elements.
+    #[test]
+    fn test_zero_does_not_overflow_allocation() {
+        for needle_len in [1, 3, 5, 10, 20, 50] {
+            for haystack_len in [16usize, 32, 64, 128, 256, 512] {
+                let haystack_chunks = haystack_len.div_ceil(16) + 1;
+                let allocated = (needle_len + 1) * haystack_chunks;
+
+                // zero() must write at most `allocated` elements
+                let zeroed = haystack_chunks * (needle_len + 1);
+                assert!(
+                    zeroed <= allocated,
+                    "zero() writes {zeroed} elements but only {allocated} were allocated \
+                     (needle_len={needle_len}, haystack_len={haystack_len})"
+                );
+
+                // The buggy version: (haystack_chunks + 1) * (needle_len + 1)
+                let buggy_zeroed = (haystack_chunks + 1) * (needle_len + 1);
+                assert!(
+                    buggy_zeroed > allocated,
+                    "expected buggy formula to overflow \
+                     (needle_len={needle_len}, haystack_len={haystack_len})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_zero_preserves_canary() {
+        #[cfg(target_arch = "x86_64")]
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            use crate::simd::{AVXVector, Vector};
+            let needle_len = 10;
+            let haystack_len = 512; // MAX_HAYSTACK_LEN in algo.rs
+
+            let mut matrix: Matrix<AVXVector> = Matrix::new(needle_len, haystack_len);
+
+            // Push a canary element at the end of the vec
+            let canary = unsafe { AVXVector::splat_u16(0xBEEF) };
+            matrix.matrix.push(canary);
+
+            // Zero the matrix — this must not touch the canary
+            matrix.zero();
+
+            // Verify the canary is untouched
+            let last = matrix.matrix.last().unwrap();
+            let canary_slice: &[u16; 16] =
+                unsafe { std::mem::transmute::<&AVXVector, &[u16; 16]>(last) };
+            for &val in canary_slice {
+                assert_eq!(
+                    val, 0xBEEF,
+                    "canary was overwritten — zero() wrote past the allocation"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
new() allocates (needle_len + 1) * haystack_chunks elements:

let haystack_chunks = haystack_len.div_ceil(16) + 1;  //  33 for MAX_HAYSTACK_LEN=512 let matrix = (0..((needle_len + 1) * haystack_chunks)) // 33 * (needle_len + 1) elements

zero() writes (haystack_chunks + 1) * (needle_len + 1) elements: (self.haystack_chunks + 1) * (self.needle_len + 1)  // 34 * (needle_len + 1) elements

That + 1 on haystack_chunks means it writes (needle_len + 1) extra Simd256 elements past the end of the allocation — a heap buffer overflow.

For a 5-character needle, that's 6 * 32 = 192 bytes of heap overflow, which eventually triggers glibc's double free or corruption when the Vec is dropped.