### PR TITLE
feat: track match end column position via match_end_col feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
 serde = ["dep:serde"]
+match_end_col = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub struct Match {
     /// Column position (0-based haystack byte offset) where the best alignment ends.
     /// Only populated when the `match_end_col` feature is enabled.
     #[cfg(feature = "match_end_col")]
-    pub match_end_col: u16,
+    pub end_col: u16,
 }
 
 impl Match {
@@ -148,7 +148,7 @@ impl Match {
             index: index as u32,
             exact: false,
             #[cfg(feature = "match_end_col")]
-            match_end_col: 0,
+            end_col: 0,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,8 @@
 //!             index: index as u32,
 //!             score,
 //!             exact,
+//!             #[cfg(feature = "match_end_col")]
+//!             match_end_col: 0,
 //!         })
 //!     })
 //!     .collect::<Vec<_>>();
@@ -133,6 +135,10 @@ pub struct Match {
     pub index: u32,
     /// Matched the needle exactly (e.g. "foo" on "foo")
     pub exact: bool,
+    /// Column position (0-based haystack byte offset) where the best alignment ends.
+    /// Only populated when the `match_end_col` feature is enabled.
+    #[cfg(feature = "match_end_col")]
+    pub match_end_col: u16,
 }
 
 impl Match {
@@ -141,6 +147,8 @@ impl Match {
             score: 0,
             index: index as u32,
             exact: false,
+            #[cfg(feature = "match_end_col")]
+            match_end_col: 0,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@
 //!             score,
 //!             exact,
 //!             #[cfg(feature = "match_end_col")]
-//!             match_end_col: 0,
+//!             end_col: 0,
 //!         })
 //!     })
 //!     .collect::<Vec<_>>();

--- a/src/one_shot/matcher.rs
+++ b/src/one_shot/matcher.rs
@@ -107,12 +107,9 @@ impl Matcher {
                 continue;
             }
 
-            let (matched, skipped_chunks) =
-                self.config
-                    .max_typos
-                    .map_or((true, 0), |max_typos| {
-                        self.prefilter.match_haystack(haystack, max_typos)
-                    });
+            let (matched, skipped_chunks) = self.config.max_typos.map_or((true, 0), |max_typos| {
+                self.prefilter.match_haystack(haystack, max_typos)
+            });
             if !matched {
                 continue;
             }
@@ -156,12 +153,9 @@ impl Matcher {
                 continue;
             }
 
-            let (matched, skipped_chunks) =
-                self.config
-                    .max_typos
-                    .map_or((true, 0), |max_typos| {
-                        self.prefilter.match_haystack(haystack, max_typos)
-                    });
+            let (matched, skipped_chunks) = self.config.max_typos.map_or((true, 0), |max_typos| {
+                self.prefilter.match_haystack(haystack, max_typos)
+            });
             if !matched {
                 continue;
             }
@@ -274,7 +268,7 @@ impl Matcher {
             score,
             exact,
             #[cfg(feature = "match_end_col")]
-            match_end_col: self.smith_waterman.end_col(),
+            match_end_col: self.smith_waterman.match_end_col(haystack),
         })
     }
 

--- a/src/one_shot/matcher.rs
+++ b/src/one_shot/matcher.rs
@@ -46,6 +46,8 @@ impl Matcher {
                     index: index as u32,
                     score: 0,
                     exact: false,
+                    #[cfg(feature = "match_end_col")]
+                    match_end_col: 0,
                 })
                 .collect();
         }
@@ -271,6 +273,8 @@ impl Matcher {
             index,
             score,
             exact,
+            #[cfg(feature = "match_end_col")]
+            match_end_col: self.smith_waterman.end_col(),
         })
     }
 
@@ -457,5 +461,23 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].index, 0);
         assert!(matches[0].exact);
+    }
+
+    #[test]
+    #[cfg(feature = "match_end_col")]
+    fn test_match_end_col_through_match_list() {
+        let config = Config {
+            max_typos: None,
+            sort: false,
+            ..Config::default()
+        };
+        let matches = match_list("abc", &["xabcx", "abcdef", "xxabc"], &config);
+        assert_eq!(matches.len(), 3);
+        // "abc" in "xabcx" ends at byte position 3
+        assert_eq!(matches[0].match_end_col, 3);
+        // "abc" in "abcdef" ends at byte position 2
+        assert_eq!(matches[1].match_end_col, 2);
+        // "abc" in "xxabc" ends at byte position 4
+        assert_eq!(matches[2].match_end_col, 4);
     }
 }

--- a/src/one_shot/matcher.rs
+++ b/src/one_shot/matcher.rs
@@ -47,7 +47,7 @@ impl Matcher {
                     score: 0,
                     exact: false,
                     #[cfg(feature = "match_end_col")]
-                    match_end_col: 0,
+                    end_col: 0,
                 })
                 .collect();
         }
@@ -268,7 +268,7 @@ impl Matcher {
             score,
             exact,
             #[cfg(feature = "match_end_col")]
-            match_end_col: self.smith_waterman.match_end_col(haystack),
+            end_col: self.smith_waterman.match_end_col(haystack),
         })
     }
 
@@ -468,10 +468,10 @@ mod tests {
         let matches = match_list("abc", &["xabcx", "abcdef", "xxabc"], &config);
         assert_eq!(matches.len(), 3);
         // "abc" in "xabcx" ends at byte position 3
-        assert_eq!(matches[0].match_end_col, 3);
+        assert_eq!(matches[0].end_col, 3);
         // "abc" in "abcdef" ends at byte position 2
-        assert_eq!(matches[1].match_end_col, 2);
+        assert_eq!(matches[1].end_col, 2);
         // "abc" in "xxabc" ends at byte position 4
-        assert_eq!(matches[2].match_end_col, 4);
+        assert_eq!(matches[2].end_col, 4);
     }
 }

--- a/src/one_shot/parallel.rs
+++ b/src/one_shot/parallel.rs
@@ -22,6 +22,8 @@ pub fn match_list_parallel<S1: AsRef<str>, S2: AsRef<str> + Sync>(
                 index: index as u32,
                 score: 0,
                 exact: false,
+                #[cfg(feature = "match_end_col")]
+                match_end_col: 0,
             })
             .collect();
     }

--- a/src/one_shot/parallel.rs
+++ b/src/one_shot/parallel.rs
@@ -23,7 +23,7 @@ pub fn match_list_parallel<S1: AsRef<str>, S2: AsRef<str> + Sync>(
                 score: 0,
                 exact: false,
                 #[cfg(feature = "match_end_col")]
-                match_end_col: 0,
+                end_col: 0,
             })
             .collect();
     }

--- a/src/smith_waterman/simd/algo.rs
+++ b/src/smith_waterman/simd/algo.rs
@@ -28,10 +28,6 @@ pub struct SmithWatermanMatcherInternal<Simd128: Vector128Expansion<Simd256>, Si
     /// Actual haystack chunks for the most recent score_haystack call.
     /// The matrix stride is always MAX_HAYSTACK_CHUNKS for zero-free reuse.
     pub haystack_chunks: usize,
-    /// Column position (0-based haystack byte offset) where the best alignment ends.
-    /// Only meaningful when the `match_end_col` feature is enabled.
-    #[cfg(feature = "match_end_col")]
-    pub end_col: u16,
     phantom: PhantomData<Simd256>,
 }
 
@@ -46,8 +42,6 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
             score_matrix: Matrix::new(needle.len(), MAX_HAYSTACK_LEN),
             match_masks: Matrix::new(needle.len(), MAX_HAYSTACK_LEN),
             haystack_chunks: 0,
-            #[cfg(feature = "match_end_col")]
-            end_col: 0,
             phantom: PhantomData,
         }
     }
@@ -64,13 +58,6 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
     pub fn match_haystack(&mut self, haystack: &[u8], max_typos: Option<u16>) -> Option<u16> {
         if haystack.len() > MAX_HAYSTACK_LEN {
             let result = match_greedy(self.needle.as_bytes(), haystack, &self.scoring);
-            #[cfg(feature = "match_end_col")]
-            {
-                self.end_col = result
-                    .as_ref()
-                    .and_then(|(_, indices)| indices.last().copied())
-                    .unwrap_or(0) as u16;
-            }
             return result.map(|(score, _)| score);
         }
 
@@ -116,13 +103,6 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
     pub fn score_haystack(&mut self, haystack: &[u8]) -> u16 {
         if haystack.len() > MAX_HAYSTACK_LEN {
             let result = match_greedy(self.needle.as_bytes(), haystack, &self.scoring);
-            #[cfg(feature = "match_end_col")]
-            {
-                self.end_col = result
-                    .as_ref()
-                    .and_then(|(_, indices)| indices.last().copied())
-                    .unwrap_or(0) as u16;
-            }
             return result.map(|(score, _)| score).unwrap_or(0);
         }
 
@@ -154,10 +134,6 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
             let mut prev_chunk_char_is_delimiter_mask = Simd128::zero();
             let mut prev_chunk_is_lower_mask = Simd128::zero();
             let mut max_scores = Simd256::zero();
-            #[cfg(feature = "match_end_col")]
-            let mut end_col_max: u16 = 0;
-            #[cfg(feature = "match_end_col")]
-            let mut end_col_val: u16 = 0;
 
             // TODO: try doing N needle chars per haystack chunk for better cache locality
             for (col_idx, haystack) in (0..(haystack_chunks - 1)).map(|col_idx| {
@@ -267,26 +243,33 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
                 }
 
                 // because we do this after the loop, we're guaranteed to be on the last row
-                #[cfg(feature = "match_end_col")]
-                {
-                    let chunk_max = row_scores.smax_u16();
-                    if chunk_max > end_col_max {
-                        end_col_max = chunk_max;
-                        let lane = row_scores.idx_u16(chunk_max);
-                        end_col_val = ((col_idx - 1) * 16 + lane) as u16;
-                    }
-                }
                 max_scores = max_scores.max_u16(row_scores);
                 prefix_bonus_masked = Simd256::zero();
             }
 
-            #[cfg(feature = "match_end_col")]
-            {
-                self.end_col = end_col_val;
-            }
-
             max_scores.smax_u16()
         }
+    }
+
+    pub fn match_end_col(&self, haystack: &[u8]) -> u16 {
+        if haystack.len() > MAX_HAYSTACK_LEN {
+            return match_greedy(self.needle.as_bytes(), haystack, &self.scoring)
+                .and_then(|(_, indices)| indices.last().copied())
+                .unwrap_or(0) as u16;
+        }
+
+        let mut match_end_col: u16 = 0;
+        let mut max_score = 0;
+        for col_idx in 1..(haystack.len().div_ceil(16) + 1) {
+            let chunk_scores = self.score_matrix.get(self.needle.len(), col_idx);
+            let chunk_max_score = unsafe { chunk_scores.smax_u16() };
+            if chunk_max_score > max_score {
+                max_score = chunk_max_score;
+                let lane = unsafe { chunk_scores.idx_u16(chunk_max_score) };
+                match_end_col = ((col_idx - 1) * 16 + lane) as u16;
+            }
+        }
+        match_end_col
     }
 
     #[cfg(test)]

--- a/src/smith_waterman/simd/algo.rs
+++ b/src/smith_waterman/simd/algo.rs
@@ -28,6 +28,10 @@ pub struct SmithWatermanMatcherInternal<Simd128: Vector128Expansion<Simd256>, Si
     /// Actual haystack chunks for the most recent score_haystack call.
     /// The matrix stride is always MAX_HAYSTACK_CHUNKS for zero-free reuse.
     pub haystack_chunks: usize,
+    /// Column position (0-based haystack byte offset) where the best alignment ends.
+    /// Only meaningful when the `match_end_col` feature is enabled.
+    #[cfg(feature = "match_end_col")]
+    pub end_col: u16,
     phantom: PhantomData<Simd256>,
 }
 
@@ -42,6 +46,8 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
             score_matrix: Matrix::new(needle.len(), MAX_HAYSTACK_LEN),
             match_masks: Matrix::new(needle.len(), MAX_HAYSTACK_LEN),
             haystack_chunks: 0,
+            #[cfg(feature = "match_end_col")]
+            end_col: 0,
             phantom: PhantomData,
         }
     }
@@ -57,8 +63,15 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
     #[inline(always)]
     pub fn match_haystack(&mut self, haystack: &[u8], max_typos: Option<u16>) -> Option<u16> {
         if haystack.len() > MAX_HAYSTACK_LEN {
-            return match_greedy(self.needle.as_bytes(), haystack, &self.scoring)
-                .map(|(score, _)| score);
+            let result = match_greedy(self.needle.as_bytes(), haystack, &self.scoring);
+            #[cfg(feature = "match_end_col")]
+            {
+                self.end_col = result
+                    .as_ref()
+                    .and_then(|(_, indices)| indices.last().copied())
+                    .unwrap_or(0) as u16;
+            }
+            return result.map(|(score, _)| score);
         }
 
         let score = self.score_haystack(haystack);
@@ -102,9 +115,15 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
     #[inline(always)]
     pub fn score_haystack(&mut self, haystack: &[u8]) -> u16 {
         if haystack.len() > MAX_HAYSTACK_LEN {
-            return match_greedy(self.needle.as_bytes(), haystack, &self.scoring)
-                .map(|(score, _)| score)
-                .unwrap_or(0);
+            let result = match_greedy(self.needle.as_bytes(), haystack, &self.scoring);
+            #[cfg(feature = "match_end_col")]
+            {
+                self.end_col = result
+                    .as_ref()
+                    .and_then(|(_, indices)| indices.last().copied())
+                    .unwrap_or(0) as u16;
+            }
+            return result.map(|(score, _)| score).unwrap_or(0);
         }
 
         let scoring = &self.scoring;
@@ -135,6 +154,10 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
             let mut prev_chunk_char_is_delimiter_mask = Simd128::zero();
             let mut prev_chunk_is_lower_mask = Simd128::zero();
             let mut max_scores = Simd256::zero();
+            #[cfg(feature = "match_end_col")]
+            let mut end_col_max: u16 = 0;
+            #[cfg(feature = "match_end_col")]
+            let mut end_col_val: u16 = 0;
 
             // TODO: try doing N needle chars per haystack chunk for better cache locality
             for (col_idx, haystack) in (0..(haystack_chunks - 1)).map(|col_idx| {
@@ -244,8 +267,22 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
                 }
 
                 // because we do this after the loop, we're guaranteed to be on the last row
+                #[cfg(feature = "match_end_col")]
+                {
+                    let chunk_max = row_scores.smax_u16();
+                    if chunk_max > end_col_max {
+                        end_col_max = chunk_max;
+                        let lane = row_scores.idx_u16(chunk_max);
+                        end_col_val = ((col_idx - 1) * 16 + lane) as u16;
+                    }
+                }
                 max_scores = max_scores.max_u16(row_scores);
                 prefix_bonus_masked = Simd256::zero();
+            }
+
+            #[cfg(feature = "match_end_col")]
+            {
+                self.end_col = end_col_val;
             }
 
             max_scores.smax_u16()

--- a/src/smith_waterman/simd/algo.rs
+++ b/src/smith_waterman/simd/algo.rs
@@ -57,8 +57,8 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
     #[inline(always)]
     pub fn match_haystack(&mut self, haystack: &[u8], max_typos: Option<u16>) -> Option<u16> {
         if haystack.len() > MAX_HAYSTACK_LEN {
-            let result = match_greedy(self.needle.as_bytes(), haystack, &self.scoring);
-            return result.map(|(score, _)| score);
+            return match_greedy(self.needle.as_bytes(), haystack, &self.scoring)
+                .map(|(score, _)| score);
         }
 
         let score = self.score_haystack(haystack);
@@ -102,8 +102,9 @@ impl<Simd128: Vector128Expansion<Simd256>, Simd256: Vector256>
     #[inline(always)]
     pub fn score_haystack(&mut self, haystack: &[u8]) -> u16 {
         if haystack.len() > MAX_HAYSTACK_LEN {
-            let result = match_greedy(self.needle.as_bytes(), haystack, &self.scoring);
-            return result.map(|(score, _)| score).unwrap_or(0);
+            return match_greedy(self.needle.as_bytes(), haystack, &self.scoring)
+                .map(|(score, _)| score)
+                .unwrap_or(0);
         }
 
         let scoring = &self.scoring;

--- a/src/smith_waterman/simd/mod.rs
+++ b/src/smith_waterman/simd/mod.rs
@@ -75,6 +75,18 @@ impl SmithWatermanMatcher {
         }
     }
 
+    #[cfg(feature = "match_end_col")]
+    pub fn end_col(&self) -> u16 {
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::AVX2(m) => m.0.end_col,
+            #[cfg(target_arch = "x86_64")]
+            Self::SSE(m) => m.0.end_col,
+            #[cfg(target_arch = "aarch64")]
+            Self::NEON(m) => m.0.end_col,
+        }
+    }
+
     pub fn score_haystack(&mut self, haystack: &[u8]) -> u16 {
         match self {
             #[cfg(target_arch = "x86_64")]
@@ -351,6 +363,26 @@ mod tests {
     #[test]
     fn test_score_continuous_beats_capitalization() {
         assert!(get_score("fo", "foo") > get_score("fo", "faOo"));
+    }
+
+    #[cfg(feature = "match_end_col")]
+    fn get_end_col(needle: &str, haystack: &str) -> u16 {
+        let mut matcher = SmithWatermanMatcher::new(needle.as_bytes(), &Scoring::default());
+        matcher.match_haystack(haystack.as_bytes(), None);
+        matcher.end_col()
+    }
+
+    #[test]
+    #[cfg(feature = "match_end_col")]
+    fn test_end_col_basic() {
+        // "abc" in "abcdef" should end at column 2 (0-indexed byte position of 'c')
+        assert_eq!(get_end_col("abc", "abcdef"), 2);
+        // "a" in "abc" should end at column 0
+        assert_eq!(get_end_col("a", "abc"), 0);
+        // "c" in "abc" should end at column 2
+        assert_eq!(get_end_col("c", "abc"), 2);
+        // "def" in "abcdef" should end at column 5
+        assert_eq!(get_end_col("def", "abcdef"), 5);
     }
 
     #[test]

--- a/src/smith_waterman/simd/mod.rs
+++ b/src/smith_waterman/simd/mod.rs
@@ -75,18 +75,6 @@ impl SmithWatermanMatcher {
         }
     }
 
-    #[cfg(feature = "match_end_col")]
-    pub fn end_col(&self) -> u16 {
-        match self {
-            #[cfg(target_arch = "x86_64")]
-            Self::AVX2(m) => m.0.end_col,
-            #[cfg(target_arch = "x86_64")]
-            Self::SSE(m) => m.0.end_col,
-            #[cfg(target_arch = "aarch64")]
-            Self::NEON(m) => m.0.end_col,
-        }
-    }
-
     pub fn score_haystack(&mut self, haystack: &[u8]) -> u16 {
         match self {
             #[cfg(target_arch = "x86_64")]
@@ -95,6 +83,18 @@ impl SmithWatermanMatcher {
             Self::SSE(matcher) => unsafe { matcher.score_haystack(haystack) },
             #[cfg(target_arch = "aarch64")]
             Self::NEON(matcher) => unsafe { matcher.score_haystack(haystack) },
+        }
+    }
+
+    #[cfg(feature = "match_end_col")]
+    pub fn match_end_col(&self, haystack: &[u8]) -> u16 {
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::AVX2(matcher) => unsafe { matcher.match_end_col(haystack) },
+            #[cfg(target_arch = "x86_64")]
+            Self::SSE(matcher) => unsafe { matcher.match_end_col(haystack) },
+            #[cfg(target_arch = "aarch64")]
+            Self::NEON(matcher) => unsafe { matcher.match_end_col(haystack) },
         }
     }
 
@@ -210,6 +210,16 @@ macro_rules! define_matcher {
             #[target_feature(enable = $feature)]
             pub unsafe fn score_haystack(&mut self, haystack: &[u8]) -> u16 {
                 self.0.score_haystack(haystack)
+            }
+
+            #[doc = concat!(
+                "Get the index of the final needle char in the haystack\n\n",
+                "# Safety\n\n",
+                "Caller must ensure that the target feature `", $feature, "` is available"
+            )]
+            #[target_feature(enable = $feature)]
+            pub unsafe fn match_end_col(&self, haystack: &[u8]) -> u16 {
+                self.0.match_end_col(haystack)
             }
 
             #[cfg(test)]
@@ -369,7 +379,7 @@ mod tests {
     fn get_end_col(needle: &str, haystack: &str) -> u16 {
         let mut matcher = SmithWatermanMatcher::new(needle.as_bytes(), &Scoring::default());
         matcher.match_haystack(haystack.as_bytes(), None);
-        matcher.end_col()
+        matcher.match_end_col(haystack.as_bytes())
     }
 
     #[test]

--- a/src/smith_waterman/simd/mod.rs
+++ b/src/smith_waterman/simd/mod.rs
@@ -393,6 +393,8 @@ mod tests {
         assert_eq!(get_end_col("c", "abc"), 2);
         // "def" in "abcdef" should end at column 5
         assert_eq!(get_end_col("def", "abcdef"), 5);
+        // "def" in "abcdef" should end at column 21
+        assert_eq!(get_end_col("def", "________________abcdef"), 21);
     }
 
     #[test]


### PR DESCRIPTION
feat: Track end col index in smith waterman

This is a backport of my old PR to buse the new architecture, I hide the
whole feature behind the feature flag so it doesn't affect existing
benchmarks at all but this gives me a very large performace boost for
detecting filename matches at fff