### PR TITLE
fix(alignment_iter): handle empty haystack instead of panicking (closes #64)

### DIFF
--- a/src/smith_waterman/simd/alignment_iter.rs
+++ b/src/smith_waterman/simd/alignment_iter.rs
@@ -87,6 +87,14 @@ impl<'a> AlignmentPathIter<'a> {
         haystack_chunks: usize,
         score: u16,
     ) -> usize {
+        // No haystack data: only the always-zero initial column exists, so the
+        // smith-waterman matrix's "final row" has no real scores to find. The
+        // iterator's `col_idx < 16` early-out at next() handles this cleanly
+        // without yielding any positions. Closes #64 (empty-haystack repro)
+        // and the empty-haystack class of saghen/blink.cmp#2499.
+        if haystack_chunks <= 1 {
+            return 0;
+        }
         for chunk_idx in 1..haystack_chunks {
             let chunk = &score_matrix.get(needle_len, chunk_idx);
             let idx = unsafe { chunk.idx_u16(score) };

--- a/src/smith_waterman/simd/mod.rs
+++ b/src/smith_waterman/simd/mod.rs
@@ -484,4 +484,46 @@ mod tests {
         assert_eq!(get_indices("ac", "________________abc"), Some(vec![18, 16]));
         assert_eq!(get_indices("foo", "Uf"), Some(vec![1]));
     }
+
+    /// Regression test for the panic at `alignment_iter.rs:97`
+    /// ("could not find max score in score matrix final row").
+    ///
+    /// An empty haystack reaches the smith-waterman matcher through two paths:
+    ///
+    /// - `match_haystack` with `max_typos = Some(_)`, which calls
+    ///   `has_alignment_path` → `AlignmentPathIter::new` → `get_col_idx`.
+    /// - `match_haystack_indices` (always uses `iter_alignment_path`).
+    ///
+    /// In both cases `haystack_chunks` is 1 (only the always-zero initial
+    /// column), so the chunk-search loop in `get_col_idx` ran zero iterations
+    /// and fell through to the panic. Reported in saghen/frizbee#64 and
+    /// surfaced in saghen/blink.cmp#2499 (where blink.cmp passes empty
+    /// completion candidates from cmdline mode).
+    #[test]
+    fn test_score_empty_haystack_with_typos_does_not_panic() {
+        let mut matcher = SmithWatermanMatcher::new(b"h", &Scoring::default());
+        // Pre-fix: this panicked at alignment_iter.rs because get_col_idx had
+        // no chunks to scan. Post-fix: empty haystack with enough typo budget
+        // to skip every needle char returns Some(0).
+        assert_eq!(matcher.match_haystack(b"", Some(1)), Some(0));
+        // max_typos < needle_len correctly rejects the match (no panic).
+        assert_eq!(matcher.match_haystack(b"", Some(0)), None);
+
+        let mut matcher2 = SmithWatermanMatcher::new(b"ab", &Scoring::default());
+        assert_eq!(matcher2.match_haystack(b"", Some(2)), Some(0));
+        assert_eq!(matcher2.match_haystack(b"", Some(1)), None);
+        assert_eq!(matcher2.match_haystack(b"", None), Some(0));
+    }
+
+    #[test]
+    fn test_indices_empty_haystack_does_not_panic() {
+        let mut matcher = SmithWatermanMatcher::new(b"h", &Scoring::default());
+        // match_haystack_indices always walks the alignment iterator, so this
+        // panicked pre-fix regardless of max_typos. Post-fix: returns the
+        // (score, indices) pair with an empty index list.
+        let result = matcher.match_haystack_indices(b"", 0, Some(1));
+        assert_eq!(result, Some((0, vec![])));
+        let result_no_typos = matcher.match_haystack_indices(b"", 0, None);
+        assert_eq!(result_no_typos, Some((0, vec![])));
+    }
 }


### PR DESCRIPTION
### Summary

`get_col_idx` scans haystack chunks `1..haystack_chunks` looking for the SIMD-computed max score in the score matrix's final row. When the haystack is empty, `score_haystack` sets `haystack_chunks = 1` (only the always-zero initial column), so the loop runs zero iterations and falls through to:

```
thread '<unnamed>' panicked at src/smith_waterman/simd/alignment_iter.rs:97:9:
could not find max score in score matrix final row
```

This fires on every CPU, on two reachable code paths:

- `match_haystack` with `Some(max_typos)` → `has_alignment_path` → `AlignmentPathIter::new` → `get_col_idx`
- `match_haystack_indices` (always uses `iter_alignment_path` → `AlignmentPathIter::new` → `get_col_idx`, regardless of max_typos)

Reported in #64 by @soifou. The same panic message also surfaces in [saghen/blink.cmp#2499](https://github.com/saghen/blink.cmp/issues/2499) where blink.cmp's cmdline mode appears to pass empty completion candidates.

### Empirical reproduction

On this Windows AVX2 box (i.e. unrelated to the AVX-without-AVX2 CPU path discussed in the original #64 thread):

```rust
use frizbee::*;
let cfg = Config { max_typos: Some(1), sort: true, scoring: Scoring::default() };
let _ = match_list("h", &[""], &cfg);  // panics
let _ = match_list_indices("h", &[""], &cfg);  // also panics
```

Both panic at `alignment_iter.rs:97`.

### Fix

When `haystack_chunks <= 1`, return `col_idx = 0` immediately. The iterator's existing `col_idx < 16` early-out at `next()` (line 128) handles the empty case cleanly without yielding any positions:

```diff
 fn get_col_idx<Simd256: Vector256>(
     score_matrix: &Matrix<Simd256>,
     needle_len: usize,
     haystack_chunks: usize,
     score: u16,
 ) -> usize {
+    if haystack_chunks <= 1 {
+        return 0;
+    }
     for chunk_idx in 1..haystack_chunks {
         let chunk = &score_matrix.get(needle_len, chunk_idx);
         let idx = unsafe { chunk.idx_u16(score) };
         if idx != 16 {
             return chunk_idx * 16 + idx;
         }
     }
     panic!("could not find max score in score matrix final row");
 }
```

The panic is preserved for the genuine "max score disappeared from a populated matrix" case it was originally guarding — this fix only short-circuits the unambiguous empty-input case.

### Regression tests

Two tests in `smith_waterman::simd::tests`:

- `test_score_empty_haystack_with_typos_does_not_panic` — exercises `match_haystack` with various `max_typos` values; covers both "enough typo budget to skip the whole needle → Some(0)" and "not enough → None" outcomes.
- `test_indices_empty_haystack_does_not_panic` — exercises `match_haystack_indices`, which is the always-panicking path before this fix.

Both panic at `alignment_iter.rs:97` pre-fix; both pass post-fix. The existing 66 tests are unaffected (full suite: 68 pass, 0 fail).

### Out of scope

@soifou's follow-up analysis in #64 pointing at `SSE256Vector::smax_u16()` on AVX-without-AVX2 CPUs (Sandy/Ivy Bridge era) is a separate code path I cannot reproduce on an AVX2 machine. If that's a distinct bug, this PR doesn't address it — the panic site here is unconditionally reached for empty haystacks regardless of which SIMD variant is selected.