### PR TITLE
fix(simd): avoid tripping AddressSanitizer in NEON/SSE load_partial

### DIFF
--- a/src/simd/neon.rs
+++ b/src/simd/neon.rs
@@ -33,8 +33,9 @@ impl NEONVector {
                 }
                 7 => {
                     let lo = (ptr as *const u32).read_unaligned() as u64;
-                    let hi = (ptr.add(4) as *const u32).read_unaligned() as u64;
-                    lo | ((hi & 0xFFFFFF) << 32)
+                    let mid = (ptr.add(4) as *const u16).read_unaligned() as u64;
+                    let hi = *ptr.add(6) as u64;
+                    lo | (mid << 32) | (hi << 48)
                 }
                 _ => std::hint::unreachable_unchecked(),
             };

--- a/src/simd/neon.rs
+++ b/src/simd/neon.rs
@@ -42,11 +42,6 @@ impl NEONVector {
             vcombine_u8(vreinterpret_u8_u64(vdup_n_u64(val)), vdup_n_u8(0))
         }
     }
-
-    #[inline(always)]
-    fn can_overread_8(ptr: *const u8) -> bool {
-        (ptr as usize & 0xFFF) <= (4096 - 8)
-    }
 }
 
 impl super::Vector for NEONVector {
@@ -189,23 +184,6 @@ impl super::Vector128 for NEONVector {
                 }
                 16 => vld1q_u8(data),
 
-                1..=7 if Self::can_overread_8(data) => {
-                    let lo = vld1_u8(data);
-                    // Create mask: bytes 0..len are 0xFF, rest are 0x00
-                    let mask_vals: [u8; 8] = [
-                        if 0 < len { 0xFF } else { 0 },
-                        if 1 < len { 0xFF } else { 0 },
-                        if 2 < len { 0xFF } else { 0 },
-                        if 3 < len { 0xFF } else { 0 },
-                        if 4 < len { 0xFF } else { 0 },
-                        if 5 < len { 0xFF } else { 0 },
-                        if 6 < len { 0xFF } else { 0 },
-                        if 7 < len { 0xFF } else { 0 },
-                    ];
-                    let mask = vld1_u8(mask_vals.as_ptr());
-                    let masked = vand_u8(lo, mask);
-                    vcombine_u8(masked, vdup_n_u8(0))
-                }
                 1..=7 => Self::load_partial_safe(data, len),
                 9..=15 => {
                     let lo = vld1_u8(data);

--- a/src/simd/sse.rs
+++ b/src/simd/sse.rs
@@ -43,12 +43,6 @@ impl SSEVector {
             _mm_cvtsi64_si128(val as i64)
         }
     }
-
-    #[inline(always)]
-    fn can_overread_8(ptr: *const u8) -> bool {
-        // Safe if not in last 7 bytes of a page
-        (ptr as usize & 0xFFF) <= (4096 - 8)
-    }
 }
 
 impl super::Vector for SSEVector {
@@ -193,11 +187,6 @@ impl super::Vector128 for SSEVector {
                 8 => _mm_loadl_epi64(data as *const __m128i),
                 16 => _mm_loadu_si128(data as *const __m128i),
 
-                1..=7 if Self::can_overread_8(data) => {
-                    let lo = _mm_loadl_epi64(data as *const __m128i);
-                    let mask = _mm_set_epi64x(0, (1i64 << (len * 8)) - 1);
-                    _mm_and_si128(lo, mask)
-                }
                 1..=7 => Self::load_partial_safe(data, len),
                 9..=15 => {
                     let lo = _mm_loadl_epi64(data as *const __m128i);

--- a/src/simd/sse.rs
+++ b/src/simd/sse.rs
@@ -33,9 +33,9 @@ impl SSEVector {
                 }
                 7 => {
                     let lo = (ptr as *const u32).read_unaligned() as u64;
-                    let hi = (ptr.add(4) as *const u32).read_unaligned() as u64;
-                    // Mask hi to only 3 bytes (24 bits)
-                    lo | ((hi & 0xFFFFFF) << 32)
+                    let mid = (ptr.add(4) as *const u16).read_unaligned() as u64;
+                    let hi = *ptr.add(6) as u64;
+                    lo | (mid << 32) | (hi << 48)
                 }
                 _ => std::hint::unreachable_unchecked(),
             };


### PR DESCRIPTION

The `1..=7` arm of `NEONVector::load_partial` and `SSEVector::load_partial` reads 8 bytes and masks. The `can_overread_8` guard catches page boundaries but not allocator boundaries, so ASan trips on any haystack shorter than 8 bytes, making the library unusable with cargo-fuzz + libFuzzer + ASan pipelines.

Two over-reads, same class of bug:

1. `load_partial`'s `1..=7` fast path: reroute to the existing `load_partial_safe`; drop the now-dead `can_overread_8` helper.
2. `load_partial_safe`'s `len == 7` arm reads `u32` + `u32` (8 bytes) and masks afterwards, same UB. Split into `u32` + `u16` + `u8` to load exactly seven bytes.

### Reproduction

```rust
let h = String::from("hello"); // 5 bytes, heap-allocated
let _ = frizbee::match_list("h", &[h.as_str()], &frizbee::Config::default());
```

```bash
RUSTFLAGS="-Z sanitizer=address" cargo +nightly run --release \
    --target aarch64-apple-darwin -Z build-std
```

Trips on `aarch64-apple-darwin` and `x86_64-unknown-linux-gnu`; clean post-fix.

### Verification

`cargo test --release` passes (66 unit + 6 doctests) on both targets; output is bit-identical to the masked over-read. No regression on `cargo bench --bench lib` (Chromium real data + 4 synthetic groups, within ±8% bench-noise on both targets).
