### PR TITLE
fix: gate prefilter overread behind safe_read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ raw-cpuid = "11.6" # runtime feature detection
 [features]
 serde = ["dep:serde"]
 match_end_col = []
+safe_read = []

--- a/src/prefilter/algo.rs
+++ b/src/prefilter/algo.rs
@@ -486,14 +486,22 @@ pub(crate) unsafe fn load_window<B: Backend>(
 
         let mask = B::Mask::first_n(remaining);
         let ptr = haystack.as_ptr().add(start);
-        if can_overread(ptr, B::LANES) {
-            (B::load(ptr), mask)
-        } else {
+        #[cfg(feature = "safe_read")]
+        {
             (B::load_partial(ptr, remaining, mask), mask)
+        }
+        #[cfg(not(feature = "safe_read"))]
+        {
+            if can_overread(ptr, B::LANES) {
+                (B::load(ptr), mask)
+            } else {
+                (B::load_partial(ptr, remaining, mask), mask)
+            }
         }
     }
 }
 
+#[cfg(not(feature = "safe_read"))]
 #[inline(always)]
 pub(crate) fn can_overread(ptr: *const u8, bytes: usize) -> bool {
     (ptr as usize & 0xFFF) <= (4096 - bytes)


### PR DESCRIPTION
## Summary

Add a `safe_read` cargo feature that makes prefilter tail windows use bounded partial loads instead of the page-bounded overread fast path.

## Verification

- `cargo test --release`
- `cargo test --release --features safe_read`
- `RUSTFLAGS='-Z sanitizer=address' cargo +nightly test --release -Z build-std --target x86_64-unknown-linux-gnu prefilter::tests::typo_matching_cases` fails without `safe_read` with an ASan global-buffer-overflow
- `RUSTFLAGS='-Z sanitizer=address' cargo +nightly test --release -Z build-std --target x86_64-unknown-linux-gnu --features safe_read prefilter::tests::typo_matching_cases`
