### PR TITLE
feat: unicode matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target
-/smith_waterman_macro/target
-/benches/match_list/data.txt
+/benches/data
+/simdutf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "rand 0.10.0",
  "rand_distr",
  "serde",
+ "simdutf",
 ]
 
 [[package]]
@@ -852,6 +853,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simdutf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f542752c7335a9174e7bb81112c3ca1415a7a6b6ec2c3e840aca347a30f9141"
+dependencies = [
+ "bitflags",
+ "cc",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ criterion = "0.8"
 nucleo = "0.5.0"
 rand = "0.10"
 rand_distr = "0.6"
+simdutf = "0.7.0"
 
 [[bench]]
 name = "lib"
@@ -28,6 +29,11 @@ harness = false
 [[bench]]
 name = "sort"
 harness = false
+
+[[bench]]
+name = "unicode"
+harness = false
+required-features = ["benching"]
 
 [[test]]
 name = "fuzz_api_equivalence"
@@ -53,6 +59,12 @@ path = "fuzz/targets/smith_waterman.rs"
 harness = false
 required-features = ["fuzzing"]
 
+[[test]]
+name = "fuzz_unicode"
+path = "fuzz/targets/unicode.rs"
+harness = false
+required-features = ["fuzzing"]
+
 [lib]
 bench = false
 
@@ -61,6 +73,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
 serde = ["dep:serde"]
+benching = []
 match_end_col = []
 safe_read = []
 fuzzing = []

--- a/benches/data/download.sh
+++ b/benches/data/download.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# chromium
+echo "Downloading chromium benchmark data..."
+curl -L -o benches/data/chromium.txt https://gist.github.com/ii14/637689ef8d071824e881a78044670310/raw/dc1dbc859daa38b62f4b9a69dec1fc599e4735e7/data.txt
+
+# unicode
+echo "Downloading unicode benchmark data..."
+curl -L -o benches/data/unicode.tar.gz https://github.com/lemire/unicode_lipsum/archive/refs/heads/main.tar.gz
+echo "Extracting unicode benchmark data..."
+rm -r benches/data/unicode
+mkdir benches/data/unicode
+tar -xzf benches/data/unicode.tar.gz --strip-components=1 -C benches/data/unicode
+rm benches/data/unicode.tar.gz
+echo "Done"

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -7,8 +7,8 @@ use match_list::{match_list_bench, match_list_generated_bench};
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Bench on real data
-    let haystack_bytes = std::fs::read("benches/match_list/data.txt")
-        .expect("Failed to read benchmark data. Run `wget -O benches/match_list/data.txt https://gist.github.com/ii14/637689ef8d071824e881a78044670310/raw/dc1dbc859daa38b62f4b9a69dec1fc599e4735e7/data.txt`");
+    let haystack_bytes = std::fs::read("benches/data/chromium.txt")
+        .expect("Failed to read benchmark data. Run `./benches/data/download.sh`");
     let haystack_str =
         String::from_utf8(haystack_bytes).expect("Failed to parse chromium benchmark data");
     let haystack = haystack_str.split('\n').collect::<Vec<_>>();

--- a/benches/unicode.rs
+++ b/benches/unicode.rs
@@ -1,0 +1,113 @@
+use std::{
+    hint::black_box,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+const DATASETS: &[(&str, &str)] = &[
+    ("Arabic", "lipsum/Arabic-Lipsum.utf8.txt"),
+    ("Chinese", "lipsum/Chinese-Lipsum.utf8.txt"),
+    ("Emoji", "lipsum/Emoji-Lipsum.utf8.txt"),
+    ("Hebrew", "lipsum/Hebrew-Lipsum.utf8.txt"),
+    ("Hindi", "lipsum/Hindi-Lipsum.utf8.txt"),
+    ("Japanese", "lipsum/Japanese-Lipsum.utf8.txt"),
+    ("Korean", "lipsum/Korean-Lipsum.utf8.txt"),
+    ("Latin", "lipsum/Latin-Lipsum.utf8.txt"),
+    ("Russian", "lipsum/Russian-Lipsum.utf8.txt"),
+];
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let datasets = load_datasets(&PathBuf::from("benches/data/unicode"));
+
+    let mut group = c.benchmark_group("Unicode UTF-8 to UTF-32");
+    for (name, input) in &datasets {
+        group.throughput(Throughput::Bytes(input.len() as u64));
+
+        #[cfg(target_arch = "x86_64")]
+        if frizbee::unicode::backend::avx512_is_available() {
+            group.bench_with_input(BenchmarkId::new("AVX-512", name), input, |b, input| {
+                let mut output = Vec::with_capacity(input.len());
+                b.iter(|| unsafe {
+                    output.clear();
+                    frizbee::unicode::backend::convert_avx512_into(
+                        black_box(input.as_str()),
+                        &mut output,
+                    );
+                    black_box(output.len())
+                });
+            });
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        if frizbee::unicode::backend::avx2_is_available() {
+            group.bench_with_input(BenchmarkId::new("AVX2", name), input, |b, input| {
+                let mut output = Vec::with_capacity(input.len());
+                b.iter(|| unsafe {
+                    output.clear();
+                    frizbee::unicode::backend::convert_avx2_into(
+                        black_box(input.as_str()),
+                        &mut output,
+                    );
+                    black_box(output.len())
+                });
+            });
+        }
+
+        group.bench_with_input(BenchmarkId::new("simdutf", name), input, |b, input| {
+            let mut output = Vec::with_capacity(input.len());
+            b.iter(|| unsafe {
+                let bytes = black_box(input.as_bytes());
+                output.clear();
+                let written = simdutf::convert_valid_utf8_to_utf32(
+                    bytes.as_ptr(),
+                    bytes.len(),
+                    output.as_mut_ptr(),
+                );
+                output.set_len(written);
+                black_box(output.len())
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("Scalar", name), input, |b, input| {
+            let mut output = Vec::with_capacity(input.len());
+            b.iter(|| {
+                output.clear();
+                frizbee::unicode::backend::convert_scalar_into(
+                    black_box(input.as_str()),
+                    &mut output,
+                );
+                black_box(output.len())
+            });
+        });
+    }
+}
+
+fn load_datasets(root: &Path) -> Vec<(&'static str, String)> {
+    DATASETS
+        .iter()
+        .map(|&(name, relative_path)| {
+            let path = root.join(relative_path);
+            let input = std::fs::read_to_string(&path).unwrap_or_else(|err| {
+                panic!(
+                    "failed to read simdutf unicode_lipsum dataset {}: {err}\n\
+                     expected root: {}\n\
+                     download with: ./benches/data/download.sh",
+                    path.display(),
+                    root.display()
+                )
+            });
+            (name, input)
+        })
+        .collect()
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_millis(200))
+        .measurement_time(Duration::from_secs(2));
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,11 @@
             toolchainWithTargets
             aflplusplus
             cargo-bolero
+            gcc
+          ];
+
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            pkgs.stdenv.cc.cc.lib
           ];
         };
       }

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -12,12 +12,14 @@ cargo test --features fuzzing --test fuzz_api_equivalence
 cargo test --features fuzzing --test fuzz_prefilter
 cargo test --features fuzzing --test fuzz_smith_waterman
 cargo test --features fuzzing --test fuzz_long_inputs
+cargo test --features fuzzing --test fuzz_unicode
 
 # AFL
 cargo bolero test --features fuzzing --engine afl --corpus-dir fuzz/corpus/api_equivalence fuzz_api_equivalence
 cargo bolero test --features fuzzing --engine afl --corpus-dir fuzz/corpus/prefilter fuzz_prefilter
 cargo bolero test --features fuzzing --engine afl --corpus-dir fuzz/corpus/smith_waterman fuzz_smith_waterman
 cargo bolero test --features fuzzing --engine afl --corpus-dir fuzz/corpus/long_inputs fuzz_long_inputs
+cargo bolero test --features fuzzing --engine afl --corpus-dir fuzz/corpus/unicode fuzz_unicode
 ```
 
 The `fuzzing` feature only exposes `frizbee::fuzz_support` to the harnesses.

--- a/fuzz/corpus/unicode/basic
+++ b/fuzz/corpus/unicode/basic
@@ -1,0 +1,1 @@
+unicode-basic

--- a/fuzz/targets/unicode.rs
+++ b/fuzz/targets/unicode.rs
@@ -1,0 +1,6 @@
+fn main() {
+    bolero::check!()
+        .with_iterations(256)
+        .with_max_len(4096)
+        .for_each(|input: &[u8]| frizbee::fuzz_support::assert_unicode(input));
+}

--- a/src/fuzz_support.rs
+++ b/src/fuzz_support.rs
@@ -776,6 +776,33 @@ fn assert_indices_valid(label: &str, needle: &[u8], haystack: &[u8], indices: &[
     }
 }
 
+pub fn assert_unicode(input: &[u8]) {
+    let mut cursor = ByteCursor::new(input);
+    let len = cursor.len(
+        512,
+        &[
+            0, 1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 63, 64, 127, 128, 255, 256,
+        ],
+    );
+    let text = cursor.unicode_string(len);
+    let want = text.chars().map(|c| c as u32).collect::<Vec<_>>();
+
+    let mut unicode = crate::unicode::Unicode::new();
+    let got = unicode.prepare(&text);
+    assert_eq!(got, want.as_slice(), "runtime Unicode conversion mismatch");
+
+    let mut scalar = crate::unicode::Unicode::new_scalar();
+    let scalar = scalar.prepare(&text);
+    assert_eq!(
+        scalar,
+        want.as_slice(),
+        "scalar Unicode conversion mismatch"
+    );
+
+    assert_eq!(unicode.prepare(&text), want.as_slice());
+    assert_eq!(unicode.needs_unicode(&text), !text.is_ascii());
+}
+
 struct ByteCursor<'a> {
     input: &'a [u8],
     pos: usize,
@@ -821,6 +848,10 @@ impl<'a> ByteCursor<'a> {
         (0..len).map(|_| self.char()).collect()
     }
 
+    fn unicode_string(&mut self, len: usize) -> String {
+        (0..len).map(|_| self.unicode_char()).collect()
+    }
+
     fn char(&mut self) -> char {
         let byte = self.next();
         match byte % 18 {
@@ -835,6 +866,33 @@ impl<'a> ByteCursor<'a> {
             8..=11 => (b'a' + (byte % 26)) as char,
             12..=15 => (b'A' + (byte % 26)) as char,
             _ => (b'0' + (byte % 10)) as char,
+        }
+    }
+
+    fn unicode_char(&mut self) -> char {
+        let byte = self.next();
+        match byte % 24 {
+            0 => '\0',
+            1 => ' ',
+            2 => '/',
+            3 => '.',
+            4 => ',',
+            5 => '_',
+            6 => '-',
+            7 => ':',
+            8..=10 => (b'a' + (byte % 26)) as char,
+            11..=12 => (b'A' + (byte % 26)) as char,
+            13 => (b'0' + (byte % 10)) as char,
+            14 => '\u{e9}',
+            15 => '\u{df}',
+            16 => '\u{416}',
+            17 => '\u{3a9}',
+            18 => '\u{4e2d}',
+            19 => '\u{6771}',
+            20 => '\u{301}',
+            21 => '\u{1f600}',
+            22 => '\u{1f680}',
+            _ => '\u{1f4a1}',
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,11 @@ mod one_shot;
 mod prefilter;
 mod smith_waterman;
 pub mod sort;
+#[cfg(feature = "benching")]
+#[doc(hidden)]
+pub mod unicode;
+#[cfg(not(feature = "benching"))]
+mod unicode;
 
 pub use k_merge::k_merge;
 pub use one_shot::{Matcher, match_list, match_list_indices, match_list_parallel};

--- a/src/unicode/backend/avx.rs
+++ b/src/unicode/backend/avx.rs
@@ -1,0 +1,741 @@
+use std::arch::x86_64::*;
+
+use super::Backend;
+
+const ONE_OR_TWO_BYTE_SHUFFLES: [[u8; 16]; 256] = build_one_or_two_byte_shuffles::<256, 8>();
+const SIX_ONE_OR_TWO_BYTE_SHUFFLES: [[u8; 16]; 64] = build_one_or_two_byte_shuffles::<64, 6>();
+const ONE_TO_THREE_BYTE_SHUFFLES: [[u8; 16]; 81] = build_one_to_three_byte_shuffles();
+const SIX_ONE_OR_TWO_BYTE_MASKS: [u16; 4096] = build_six_one_or_two_byte_masks();
+const INVALID_ONE_OR_TWO_BYTE_MASK: u16 = u16::MAX;
+const TWO_BYTE_BOUNDARY_MASK_8: u32 = 0x0001_ffff;
+const TWO_BYTE_CONTINUATION_MASK_8: u32 = 0x0000_aaaa;
+const THREE_BYTE_BOUNDARY_MASK_8: u32 = 0x00ff_ffff;
+const THREE_BYTE_CONTINUATION_MASK_8: u32 = 0x00db_6db6;
+const FOUR_BYTE_CONTINUATION_MASK_8: u32 = 0xeeee_eeee;
+
+// UTF-8 to UTF-32 conversion optimized for the case Frizbee expects most:
+// mostly-ASCII fuzzy-match inputs with occasional Unicode.
+//
+// The hot path is a pure ASCII block converter. It scans 32 bytes at a time,
+// checks the high bit with movemask, and widens bytes to u32 lanes with AVX2
+// zero-extension instructions. That path is why the Latin benchmark is close
+// to simdutf.
+//
+// A block containing any non-ASCII byte switches to mixed-width paths inspired
+// by simdutf's Haswell converter. The 64-byte loop computes byte-class masks
+// once, then shifts those masks as each small decoder consumes input. That
+// keeps the table-driven one/two-byte path from paying a fresh vector load and
+// movemask for every 6 decoded codepoints.
+//
+// Continuation masks alone do not validate UTF-8; they are only layout hints.
+// That is fine here because the public input is already a valid `str`. The
+// fast paths still have to preserve codepoint boundaries: the all-2-byte check
+// looks at one extra continuation bit so a 4-byte sequence cannot masquerade as
+// two 2-byte codepoints at the edge of the 16-byte decoder.
+//
+// Dense fixed-width cases are decoded in larger groups: six codepoints when
+// every sequence is one or two bytes, eight codepoints for all 3-byte
+// sequences, and eight codepoints for all 4-byte sequences. The fallback still
+// handles arbitrary four-codepoint groups with scalar length checks.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Utf8ToUtf32AVX2;
+
+impl Backend for Utf8ToUtf32AVX2 {
+    #[inline(always)]
+    fn is_available() -> bool {
+        is_x86_feature_detected!("avx2")
+    }
+
+    #[inline(always)]
+    unsafe fn convert_into(input: &str, out: &mut Vec<u32>) {
+        unsafe { convert_into_avx2(input, out) }
+    }
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn convert_into_avx2(input: &str, out: &mut Vec<u32>) {
+    unsafe { convert_avx2(input, out) }
+}
+
+#[inline(always)]
+unsafe fn convert_avx2(input: &str, out: &mut Vec<u32>) {
+    unsafe {
+        out.clear();
+
+        let bytes = input.as_bytes();
+        let len = bytes.len();
+        // A valid UTF-8 string never has more codepoints than bytes, so byte
+        // length is a safe upper bound for the reusable UTF-32 buffer.
+        out.reserve(len);
+
+        let input_ptr = bytes.as_ptr();
+        let output_ptr = out.as_mut_ptr();
+        let mut input_pos = 0usize;
+        let mut output_len = 0usize;
+
+        // ASCII dominates common fuzzy-match inputs. When the movemask is
+        // zero, every byte is already a complete codepoint and conversion is
+        // just zero-extension into u32 lanes.
+        while input_pos + 64 <= len {
+            let first = _mm256_loadu_si256(input_ptr.add(input_pos) as *const __m256i);
+            let second = _mm256_loadu_si256(input_ptr.add(input_pos + 32) as *const __m256i);
+            let non_ascii = _mm256_movemask_epi8(first) | _mm256_movemask_epi8(second);
+
+            if non_ascii == 0 {
+                store_ascii_32(first, output_ptr.add(output_len));
+                store_ascii_32(second, output_ptr.add(output_len + 32));
+                input_pos += 64;
+                output_len += 64;
+            } else {
+                let block_start = input_pos;
+                let mut continuation_mask = u64::from(continuation_mask_32(first))
+                    | (u64::from(continuation_mask_32(second)) << 32);
+
+                // Dense 3-byte text otherwise wastes the last bytes of each
+                // 64-byte mask window because 64 is not divisible by 3. Load a
+                // third mask only for that shape and decode through byte 80;
+                // the generic path stays at 48 so every fast decoder has the
+                // boundary bits it needs inside the original 64-byte mask.
+                if block_start + 96 <= len
+                    && (continuation_mask as u32 & THREE_BYTE_BOUNDARY_MASK_8)
+                        == THREE_BYTE_CONTINUATION_MASK_8
+                {
+                    let block_limit = block_start + 80;
+                    let mut continuation_mask_hi = continuation_mask_32(_mm256_loadu_si256(
+                        input_ptr.add(input_pos + 64) as *const __m256i,
+                    ));
+
+                    while input_pos < block_limit {
+                        let (consumed, written) = convert_masked_or_fallback(
+                            input_ptr.add(input_pos),
+                            output_ptr.add(output_len),
+                            len - input_pos,
+                            continuation_mask as u32,
+                        );
+                        input_pos += consumed;
+                        output_len += written;
+                        shift_continuation_mask(
+                            &mut continuation_mask,
+                            &mut continuation_mask_hi,
+                            consumed,
+                        );
+                    }
+                } else {
+                    let block_limit = block_start + 48;
+
+                    while input_pos < block_limit {
+                        let (consumed, written) = convert_masked_or_fallback(
+                            input_ptr.add(input_pos),
+                            output_ptr.add(output_len),
+                            len - input_pos,
+                            continuation_mask as u32,
+                        );
+                        input_pos += consumed;
+                        output_len += written;
+                        continuation_mask >>= consumed;
+                    }
+                }
+            }
+        }
+
+        while input_pos + 32 <= len {
+            let chunk = _mm256_loadu_si256(input_ptr.add(input_pos) as *const __m256i);
+            if _mm256_movemask_epi8(chunk) == 0 {
+                store_ascii_32(chunk, output_ptr.add(output_len));
+                input_pos += 32;
+                output_len += 32;
+            } else {
+                let continuation_mask = continuation_mask_32(chunk);
+                let (consumed, written) = convert_masked_or_fallback(
+                    input_ptr.add(input_pos),
+                    output_ptr.add(output_len),
+                    len - input_pos,
+                    continuation_mask,
+                );
+                input_pos += consumed;
+                output_len += written;
+            }
+        }
+
+        // Finish any remaining half-register ASCII block before handing the
+        // short tail to scalar chars().
+        while input_pos + 16 <= len {
+            let chunk = _mm_loadu_si128(input_ptr.add(input_pos) as *const __m128i);
+            if _mm_movemask_epi8(chunk) == 0 {
+                store_ascii_16(chunk, output_ptr.add(output_len));
+                input_pos += 16;
+                output_len += 16;
+            } else {
+                let (consumed, written) = convert_mixed_codepoints_fallback(
+                    input_ptr.add(input_pos),
+                    output_ptr.add(output_len),
+                    len - input_pos,
+                );
+                input_pos += consumed;
+                output_len += written;
+            }
+        }
+
+        // All SIMD stores above wrote initialized u32 lanes directly into the
+        // spare capacity. Publish only those lanes before using safe Vec
+        // extension for the short suffix.
+        out.set_len(output_len);
+        let tail = std::str::from_utf8_unchecked(&bytes[input_pos..]);
+        out.extend(tail.chars().map(|c| c as u32));
+    }
+}
+
+#[inline(always)]
+unsafe fn store_ascii_32(chunk: __m256i, output: *mut u32) {
+    unsafe {
+        let lo = _mm256_castsi256_si128(chunk);
+        let hi = _mm256_extracti128_si256::<1>(chunk);
+
+        _mm256_storeu_si256(output as *mut __m256i, _mm256_cvtepu8_epi32(lo));
+        _mm256_storeu_si256(
+            output.add(8) as *mut __m256i,
+            _mm256_cvtepu8_epi32(_mm_srli_si128::<8>(lo)),
+        );
+        _mm256_storeu_si256(output.add(16) as *mut __m256i, _mm256_cvtepu8_epi32(hi));
+        _mm256_storeu_si256(
+            output.add(24) as *mut __m256i,
+            _mm256_cvtepu8_epi32(_mm_srli_si128::<8>(hi)),
+        );
+    }
+}
+
+#[inline(always)]
+unsafe fn store_ascii_16(chunk: __m128i, output: *mut u32) {
+    unsafe {
+        _mm256_storeu_si256(output as *mut __m256i, _mm256_cvtepu8_epi32(chunk));
+        _mm256_storeu_si256(
+            output.add(8) as *mut __m256i,
+            _mm256_cvtepu8_epi32(_mm_srli_si128::<8>(chunk)),
+        );
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_masked_codepoints(
+    input: *const u8,
+    output: *mut u32,
+    continuation_mask: u32,
+) -> Option<(usize, usize)> {
+    unsafe {
+        // Check bit 16 as a boundary guard. Without it, a 4-byte sequence that
+        // starts at byte 14 has the same low 16 continuation bits as eight
+        // 2-byte sequences.
+        if (continuation_mask & TWO_BYTE_BOUNDARY_MASK_8) == TWO_BYTE_CONTINUATION_MASK_8 {
+            convert_eight_one_or_two_byte_codepoints(input, output, 0xff);
+            return Some((16, 8));
+        }
+
+        if let Some((consumed, shuffle_index)) =
+            six_one_or_two_byte_mask_from_continuation_mask(continuation_mask)
+        {
+            convert_six_one_or_two_byte_codepoints(input, output, shuffle_index);
+            return Some((consumed, 6));
+        }
+
+        if (continuation_mask & THREE_BYTE_BOUNDARY_MASK_8) == THREE_BYTE_CONTINUATION_MASK_8 {
+            convert_eight_three_byte_codepoints(input, output);
+            return Some((24, 8));
+        }
+
+        if continuation_mask == FOUR_BYTE_CONTINUATION_MASK_8 {
+            convert_eight_four_byte_codepoints(input, output);
+            return Some((32, 8));
+        }
+
+        None
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_masked_or_fallback(
+    input: *const u8,
+    output: *mut u32,
+    remaining: usize,
+    continuation_mask: u32,
+) -> (usize, usize) {
+    unsafe {
+        if let Some(decoded) = convert_masked_codepoints(input, output, continuation_mask) {
+            decoded
+        } else {
+            convert_mixed_codepoints_fallback(input, output, remaining)
+        }
+    }
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn convert_mixed_codepoints_fallback(
+    input: *const u8,
+    output: *mut u32,
+    remaining: usize,
+) -> (usize, usize) {
+    unsafe {
+        let first_len = utf8_codepoint_len(*input);
+        let second_start = first_len;
+        let second_len = utf8_codepoint_len(*input.add(second_start));
+        let third_start = second_start + second_len;
+        let third_len = utf8_codepoint_len(*input.add(third_start));
+        let fourth_start = third_start + third_len;
+        let fourth_len = utf8_codepoint_len(*input.add(fourth_start));
+
+        if first_len <= 2 && second_len <= 2 && third_len <= 2 && fourth_len <= 2 {
+            let fifth_start = fourth_start + fourth_len;
+            let fifth_len = utf8_codepoint_len(*input.add(fifth_start));
+            let sixth_start = fifth_start + fifth_len;
+            let sixth_len = utf8_codepoint_len(*input.add(sixth_start));
+            let seventh_start = sixth_start + sixth_len;
+            let seventh_len = utf8_codepoint_len(*input.add(seventh_start));
+            let eighth_start = seventh_start + seventh_len;
+            let eighth_len = utf8_codepoint_len(*input.add(eighth_start));
+
+            if fifth_len <= 2 && sixth_len <= 2 && seventh_len <= 2 && eighth_len <= 2 {
+                let consumed = eighth_start + eighth_len;
+                debug_assert!(consumed <= 16);
+                convert_eight_one_or_two_byte_codepoints(
+                    input,
+                    output,
+                    one_or_two_byte_shuffle_index([
+                        first_len,
+                        second_len,
+                        third_len,
+                        fourth_len,
+                        fifth_len,
+                        sixth_len,
+                        seventh_len,
+                        eighth_len,
+                    ]),
+                );
+                return (consumed, 8);
+            }
+        }
+
+        if first_len == 3 && second_len == 3 && third_len == 3 && fourth_len == 3 && remaining >= 24
+        {
+            let fifth_len = utf8_codepoint_len(*input.add(12));
+            let sixth_len = utf8_codepoint_len(*input.add(15));
+            let seventh_len = utf8_codepoint_len(*input.add(18));
+            let eighth_len = utf8_codepoint_len(*input.add(21));
+
+            if fifth_len == 3 && sixth_len == 3 && seventh_len == 3 && eighth_len == 3 {
+                convert_eight_three_byte_codepoints(input, output);
+                return (24, 8);
+            }
+        }
+
+        if first_len <= 3 && second_len <= 3 && third_len <= 3 && fourth_len <= 3 {
+            let consumed = fourth_start + fourth_len;
+            debug_assert!(consumed <= 12);
+            convert_four_one_to_three_byte_codepoints(
+                input,
+                output,
+                one_to_three_byte_shuffle_index([first_len, second_len, third_len, fourth_len]),
+            );
+            return (consumed, 4);
+        }
+
+        if first_len == 4 && second_len == 4 && third_len == 4 && fourth_len == 4 {
+            if remaining >= 32
+                && utf8_codepoint_len(*input.add(16)) == 4
+                && utf8_codepoint_len(*input.add(20)) == 4
+                && utf8_codepoint_len(*input.add(24)) == 4
+                && utf8_codepoint_len(*input.add(28)) == 4
+            {
+                convert_eight_four_byte_codepoints(input, output);
+                return (32, 8);
+            }
+
+            convert_four_four_byte_codepoints(input, output);
+            return (16, 4);
+        }
+
+        convert_four_codepoints(
+            input,
+            output,
+            [0, second_start, third_start, fourth_start],
+            [first_len, second_len, third_len, fourth_len],
+        )
+    }
+}
+
+#[inline(always)]
+unsafe fn continuation_mask_32(chunk: __m256i) -> u32 {
+    unsafe {
+        let continuation = _mm256_cmpgt_epi8(_mm256_set1_epi8(-64), chunk);
+        _mm256_movemask_epi8(continuation) as u32
+    }
+}
+
+#[inline(always)]
+fn shift_continuation_mask(mask: &mut u64, mask_hi: &mut u32, consumed: usize) {
+    debug_assert!((1..=32).contains(&consumed));
+
+    if consumed == 32 {
+        *mask = (*mask >> 32) | (u64::from(*mask_hi) << 32);
+        *mask_hi = 0;
+    } else {
+        *mask = (*mask >> consumed) | (u64::from(*mask_hi) << (64 - consumed));
+        *mask_hi >>= consumed;
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_six_one_or_two_byte_codepoints(
+    input: *const u8,
+    output: *mut u32,
+    shuffle_index: usize,
+) {
+    unsafe {
+        let shuffle =
+            _mm_loadu_si128(SIX_ONE_OR_TWO_BYTE_SHUFFLES[shuffle_index].as_ptr() as *const __m128i);
+        convert_one_or_two_byte_codepoints(input, output, shuffle);
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_eight_one_or_two_byte_codepoints(
+    input: *const u8,
+    output: *mut u32,
+    shuffle_index: usize,
+) {
+    unsafe {
+        let shuffle =
+            _mm_loadu_si128(ONE_OR_TWO_BYTE_SHUFFLES[shuffle_index].as_ptr() as *const __m128i);
+        convert_one_or_two_byte_codepoints(input, output, shuffle);
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_one_or_two_byte_codepoints(input: *const u8, output: *mut u32, shuffle: __m128i) {
+    unsafe {
+        let input = _mm_loadu_si128(input as *const __m128i);
+        let packed = _mm_shuffle_epi8(input, shuffle);
+        let low_payload = _mm_and_si128(packed, _mm_set1_epi16(0x7f));
+        let high_payload = _mm_and_si128(packed, _mm_set1_epi16(0x1f00));
+        let codepoints = _mm_or_si128(low_payload, _mm_srli_epi16::<2>(high_payload));
+        _mm256_storeu_si256(output as *mut __m256i, _mm256_cvtepu16_epi32(codepoints));
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_eight_three_byte_codepoints(input: *const u8, output: *mut u32) {
+    unsafe {
+        convert_four_three_byte_codepoints(input, output);
+        convert_four_three_byte_codepoints(input.add(12), output.add(4));
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_four_three_byte_codepoints(input: *const u8, output: *mut u32) {
+    unsafe {
+        let input = _mm_loadu_si128(input as *const __m128i);
+        let shuffle = _mm_setr_epi8(2, 1, 0, -1, 5, 4, 3, -1, 8, 7, 6, -1, 11, 10, 9, -1);
+        let packed = _mm_shuffle_epi8(input, shuffle);
+        let low_payload = _mm_and_si128(packed, _mm_set1_epi32(0x7f));
+        let middle_payload = _mm_and_si128(packed, _mm_set1_epi32(0x3f00));
+        let high_payload = _mm_and_si128(packed, _mm_set1_epi32(0x0f0000));
+        let codepoints = _mm_or_si128(
+            _mm_or_si128(low_payload, _mm_srli_epi32::<2>(middle_payload)),
+            _mm_srli_epi32::<4>(high_payload),
+        );
+        _mm_storeu_si128(output as *mut __m128i, codepoints);
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_four_one_to_three_byte_codepoints(
+    input: *const u8,
+    output: *mut u32,
+    shuffle_index: usize,
+) {
+    unsafe {
+        let input = _mm_loadu_si128(input as *const __m128i);
+        let shuffle =
+            _mm_loadu_si128(ONE_TO_THREE_BYTE_SHUFFLES[shuffle_index].as_ptr() as *const __m128i);
+        let packed = _mm_shuffle_epi8(input, shuffle);
+        let low_payload = _mm_and_si128(packed, _mm_set1_epi32(0x7f));
+        let middle_payload = _mm_and_si128(packed, _mm_set1_epi32(0x3f00));
+        let high_payload = _mm_and_si128(packed, _mm_set1_epi32(0x0f0000));
+        let codepoints = _mm_or_si128(
+            _mm_or_si128(low_payload, _mm_srli_epi32::<2>(middle_payload)),
+            _mm_srli_epi32::<4>(high_payload),
+        );
+        _mm_storeu_si128(output as *mut __m128i, codepoints);
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_eight_four_byte_codepoints(input: *const u8, output: *mut u32) {
+    unsafe {
+        convert_four_four_byte_codepoints(input, output);
+        convert_four_four_byte_codepoints(input.add(16), output.add(4));
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_four_four_byte_codepoints(input: *const u8, output: *mut u32) {
+    unsafe {
+        let input = _mm_loadu_si128(input as *const __m128i);
+        let shuffle = _mm_setr_epi8(3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12);
+        let packed = _mm_shuffle_epi8(input, shuffle);
+        let low_payload = _mm_and_si128(packed, _mm_set1_epi32(0x7f));
+        let middle_payload = _mm_and_si128(packed, _mm_set1_epi32(0x3f00));
+        let upper_middle_payload = _mm_and_si128(packed, _mm_set1_epi32(0x3f0000));
+        let high_payload = _mm_and_si128(packed, _mm_set1_epi32(0x07000000));
+        let correction = _mm_srli_epi32::<1>(_mm_and_si128(packed, _mm_set1_epi32(0x400000)));
+        let upper_middle_payload = _mm_xor_si128(upper_middle_payload, correction);
+        let codepoints = _mm_or_si128(
+            _mm_or_si128(low_payload, _mm_srli_epi32::<2>(middle_payload)),
+            _mm_or_si128(
+                _mm_srli_epi32::<4>(upper_middle_payload),
+                _mm_srli_epi32::<6>(high_payload),
+            ),
+        );
+        _mm_storeu_si128(output as *mut __m128i, codepoints);
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_four_codepoints(
+    input: *const u8,
+    output: *mut u32,
+    starts: [usize; 4],
+    lens: [usize; 4],
+) -> (usize, usize) {
+    unsafe {
+        // The caller only enters here while at least 16 bytes remain. Four
+        // valid UTF-8 codepoints consume at most 16 bytes, and input_pos is
+        // always advanced by whole codepoints, so all leading-byte reads and
+        // the 16-byte vector load below stay within the input.
+        let consumed = starts[3] + lens[3];
+        debug_assert!(consumed <= 16);
+
+        // Build a pshufb control vector that places each UTF-8 sequence into a
+        // u32 lane as b0|b1|b2|b3. Unused bytes in shorter sequences are
+        // zeroed. This per-call stack mask is simple, but it is one of the
+        // main costs on dense Unicode text.
+        let input = _mm_loadu_si128(input as *const __m128i);
+        let shuffle = shuffle_for_codepoints(starts, lens);
+        let packed = _mm_shuffle_epi8(input, shuffle);
+
+        // Decode all possible sequence lengths in parallel and select the
+        // correct result per lane using masks derived from the scalar lengths.
+        let byte_mask = _mm_set1_epi32(0xff);
+        let continuation_mask = _mm_set1_epi32(0x3f);
+        let first_payload_mask = _mm_set1_epi32(0x1f);
+        let second_payload_mask = _mm_set1_epi32(0x0f);
+        let third_payload_mask = _mm_set1_epi32(0x07);
+
+        let b0 = _mm_and_si128(packed, byte_mask);
+        let b1 = _mm_and_si128(_mm_srli_epi32::<8>(packed), byte_mask);
+        let b2 = _mm_and_si128(_mm_srli_epi32::<16>(packed), byte_mask);
+        let b3 = _mm_and_si128(_mm_srli_epi32::<24>(packed), byte_mask);
+
+        let cp1 = b0;
+        let cp2 = _mm_or_si128(
+            _mm_slli_epi32::<6>(_mm_and_si128(b0, first_payload_mask)),
+            _mm_and_si128(b1, continuation_mask),
+        );
+        let cp3 = _mm_or_si128(
+            _mm_or_si128(
+                _mm_slli_epi32::<12>(_mm_and_si128(b0, second_payload_mask)),
+                _mm_slli_epi32::<6>(_mm_and_si128(b1, continuation_mask)),
+            ),
+            _mm_and_si128(b2, continuation_mask),
+        );
+        let cp4 = _mm_or_si128(
+            _mm_or_si128(
+                _mm_slli_epi32::<18>(_mm_and_si128(b0, third_payload_mask)),
+                _mm_slli_epi32::<12>(_mm_and_si128(b1, continuation_mask)),
+            ),
+            _mm_or_si128(
+                _mm_slli_epi32::<6>(_mm_and_si128(b2, continuation_mask)),
+                _mm_and_si128(b3, continuation_mask),
+            ),
+        );
+
+        let codepoints = _mm_or_si128(
+            _mm_or_si128(
+                _mm_and_si128(cp1, lane_mask(lens, 1)),
+                _mm_and_si128(cp2, lane_mask(lens, 2)),
+            ),
+            _mm_or_si128(
+                _mm_and_si128(cp3, lane_mask(lens, 3)),
+                _mm_and_si128(cp4, lane_mask(lens, 4)),
+            ),
+        );
+
+        _mm_storeu_si128(output as *mut __m128i, codepoints);
+        (consumed, 4)
+    }
+}
+
+#[inline(always)]
+fn utf8_codepoint_len(first_byte: u8) -> usize {
+    if first_byte < 0x80 {
+        1
+    } else if first_byte < 0xe0 {
+        2
+    } else if first_byte < 0xf0 {
+        3
+    } else {
+        4
+    }
+}
+
+#[inline(always)]
+fn one_or_two_byte_shuffle_index(lens: [usize; 8]) -> usize {
+    let mut index = 0usize;
+    for (lane, len) in lens.into_iter().enumerate() {
+        debug_assert!((1..=2).contains(&len));
+        index |= (len - 1) << lane;
+    }
+    index
+}
+
+#[inline(always)]
+fn six_one_or_two_byte_mask_from_continuation_mask(
+    continuation_mask: u32,
+) -> Option<(usize, usize)> {
+    let entry = SIX_ONE_OR_TWO_BYTE_MASKS[(continuation_mask & 0x0fff) as usize];
+    if entry == INVALID_ONE_OR_TWO_BYTE_MASK {
+        return None;
+    }
+
+    let consumed = (entry >> 8) as usize;
+    if consumed == 12 && (continuation_mask & (1 << 12)) != 0 {
+        return None;
+    }
+
+    Some((consumed, (entry & 0x3f) as usize))
+}
+
+#[inline(always)]
+fn one_to_three_byte_shuffle_index(lens: [usize; 4]) -> usize {
+    let mut index = 0usize;
+    let mut multiplier = 1usize;
+    for len in lens {
+        debug_assert!((1..=3).contains(&len));
+        index += (len - 1) * multiplier;
+        multiplier *= 3;
+    }
+    index
+}
+
+#[inline(always)]
+unsafe fn shuffle_for_codepoints(starts: [usize; 4], lens: [usize; 4]) -> __m128i {
+    unsafe {
+        let mut mask = [0x80u8; 16];
+        for lane in 0..4 {
+            for byte in 0..lens[lane] {
+                mask[lane * 4 + byte] = (starts[lane] + byte) as u8;
+            }
+        }
+        _mm_loadu_si128(mask.as_ptr() as *const __m128i)
+    }
+}
+
+#[inline(always)]
+unsafe fn lane_mask(lens: [usize; 4], target: usize) -> __m128i {
+    unsafe {
+        _mm_setr_epi32(
+            full_mask(lens[0] == target),
+            full_mask(lens[1] == target),
+            full_mask(lens[2] == target),
+            full_mask(lens[3] == target),
+        )
+    }
+}
+
+#[inline(always)]
+fn full_mask(enabled: bool) -> i32 {
+    if enabled { -1 } else { 0 }
+}
+
+const fn build_one_or_two_byte_shuffles<const ENTRIES: usize, const LANES: usize>()
+-> [[u8; 16]; ENTRIES] {
+    let mut table = [[0x80u8; 16]; ENTRIES];
+    let mut index = 0usize;
+    while index < table.len() {
+        let mut input_pos = 0usize;
+        let mut lane = 0usize;
+        while lane < LANES {
+            let output_pos = lane * 2;
+            let len = 1 + ((index >> lane) & 1);
+            if len == 1 {
+                table[index][output_pos] = input_pos as u8;
+            } else {
+                table[index][output_pos] = (input_pos + 1) as u8;
+                table[index][output_pos + 1] = input_pos as u8;
+            }
+            input_pos += len;
+            lane += 1;
+        }
+        index += 1;
+    }
+    table
+}
+
+const fn build_six_one_or_two_byte_masks() -> [u16; 4096] {
+    let mut table = [INVALID_ONE_OR_TWO_BYTE_MASK; 4096];
+    let mut mask = 0usize;
+    while mask < table.len() {
+        table[mask] = six_one_or_two_byte_mask_entry(mask);
+        mask += 1;
+    }
+    table
+}
+
+const fn six_one_or_two_byte_mask_entry(mask: usize) -> u16 {
+    let mut input_pos = 0usize;
+    let mut shuffle_index = 0usize;
+    let mut lane = 0usize;
+
+    while lane < 6 {
+        if ((mask >> input_pos) & 1) != 0 {
+            return INVALID_ONE_OR_TWO_BYTE_MASK;
+        }
+
+        if ((mask >> (input_pos + 1)) & 1) != 0 {
+            if input_pos + 2 < 12 && ((mask >> (input_pos + 2)) & 1) != 0 {
+                return INVALID_ONE_OR_TWO_BYTE_MASK;
+            }
+            shuffle_index |= 1 << lane;
+            input_pos += 2;
+        } else {
+            input_pos += 1;
+        }
+
+        lane += 1;
+    }
+
+    ((input_pos as u16) << 8) | shuffle_index as u16
+}
+
+const fn build_one_to_three_byte_shuffles() -> [[u8; 16]; 81] {
+    let mut table = [[0x80u8; 16]; 81];
+    let mut index = 0usize;
+    while index < table.len() {
+        let mut pattern = index;
+        let mut input_pos = 0usize;
+        let mut lane = 0usize;
+        while lane < 4 {
+            let output_pos = lane * 4;
+            let len = 1 + (pattern % 3);
+            pattern /= 3;
+
+            let mut byte = 0usize;
+            while byte < len {
+                table[index][output_pos + byte] = (input_pos + len - 1 - byte) as u8;
+                byte += 1;
+            }
+            input_pos += len;
+            lane += 1;
+        }
+        index += 1;
+    }
+    table
+}

--- a/src/unicode/backend/avx512.rs
+++ b/src/unicode/backend/avx512.rs
@@ -1,0 +1,322 @@
+use std::arch::x86_64::*;
+
+use crate::prefilter::algo::can_overread;
+
+use super::Backend;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Utf8ToUtf32AVX512;
+
+impl Backend for Utf8ToUtf32AVX512 {
+    #[inline(always)]
+    fn is_available() -> bool {
+        is_x86_feature_detected!("avx512f")
+            && is_x86_feature_detected!("avx512bw")
+            && is_x86_feature_detected!("avx512vbmi")
+            && is_x86_feature_detected!("popcnt")
+    }
+
+    #[inline(always)]
+    unsafe fn convert_into(input: &str, out: &mut Vec<u32>) {
+        unsafe { convert_into_avx512(input, out) }
+    }
+}
+
+#[target_feature(enable = "avx512f,avx512bw,avx512vbmi,popcnt")]
+unsafe fn convert_into_avx512(input: &str, out: &mut Vec<u32>) {
+    unsafe { convert_avx512(input, out) }
+}
+
+#[inline(always)]
+unsafe fn convert_avx512(input: &str, out: &mut Vec<u32>) {
+    unsafe {
+        out.clear();
+
+        let bytes = input.as_bytes();
+        let len = bytes.len();
+        out.reserve(len);
+
+        let input_ptr = bytes.as_ptr();
+        let output_ptr = out.as_mut_ptr();
+        let high_bit = _mm512_set1_epi8(0x80u8 as i8);
+        let mut input_pos = 0usize;
+        let mut output_len = 0usize;
+
+        // Mixed UTF-8 looks four bytes ahead so lane-end codepoints stay vectorized.
+        while input_pos + 68 <= len {
+            let input = input_ptr.add(input_pos);
+            let chunk = _mm512_loadu_si512(input as *const __m512i);
+            if _mm512_test_epi8_mask(chunk, high_bit) == 0 {
+                store_ascii_64(chunk, output_ptr.add(output_len));
+                output_len += 64;
+            } else {
+                output_len += convert_mixed_64(chunk, input, output_ptr.add(output_len));
+            }
+            input_pos += 64;
+        }
+
+        // With 52+ tail bytes, process three lanes and leave the final lane scalar.
+        let remaining = len - input_pos;
+        if remaining >= 64 {
+            let input = input_ptr.add(input_pos);
+            let chunk = _mm512_loadu_si512(input as *const __m512i);
+            if _mm512_test_epi8_mask(chunk, high_bit) == 0 {
+                store_ascii_64(chunk, output_ptr.add(output_len));
+                output_len += 64;
+                input_pos += 64;
+            } else if can_overread(input.add(64), 4) {
+                // Page-safe overread: extra bytes only complete starts inside this block.
+                output_len += convert_mixed_64(chunk, input, output_ptr.add(output_len));
+                input_pos += 64;
+            } else {
+                output_len += convert_mixed_prefix_48(chunk, output_ptr.add(output_len));
+                input_pos += 48;
+            }
+        } else if remaining >= 52 {
+            let input = input_ptr.add(input_pos);
+            let mask = 1u64.wrapping_shl(remaining as u32).wrapping_sub(1) as __mmask64;
+            let chunk = _mm512_maskz_loadu_epi8(mask, input as *const i8);
+            output_len += convert_mixed_prefix_48(chunk, output_ptr.add(output_len));
+            input_pos += 48;
+        }
+
+        out.set_len(output_len);
+
+        // Skip continuations already consumed by the vector block before scalar tail.
+        while input_pos < len && (*input_ptr.add(input_pos) & 0xc0) == 0x80 {
+            input_pos += 1;
+        }
+
+        let tail = std::str::from_utf8_unchecked(&bytes[input_pos..]);
+        out.extend(tail.chars().map(|c| c as u32));
+    }
+}
+
+#[inline(always)]
+unsafe fn store_ascii_64(input: __m512i, output: *mut u32) {
+    unsafe {
+        // Four 16-byte zero-extends turn a 64-byte ASCII block into UTF-32.
+        let first = _mm512_castsi512_si128(input);
+        let second = _mm512_extracti32x4_epi32::<1>(input);
+        let third = _mm512_extracti32x4_epi32::<2>(input);
+        let fourth = _mm512_extracti32x4_epi32::<3>(input);
+
+        _mm512_storeu_si512(output as *mut __m512i, _mm512_cvtepu8_epi32(first));
+        _mm512_storeu_si512(output.add(16) as *mut __m512i, _mm512_cvtepu8_epi32(second));
+        _mm512_storeu_si512(output.add(32) as *mut __m512i, _mm512_cvtepu8_epi32(third));
+        _mm512_storeu_si512(output.add(48) as *mut __m512i, _mm512_cvtepu8_epi32(fourth));
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_mixed_64(input_block: __m512i, input: *const u8, output: *mut u32) -> usize {
+    unsafe {
+        let first_expanded = expand_window::<0>(input_block);
+        let second_expanded = expand_window::<16>(input_block);
+        let third_expanded = expand_window::<32>(input_block);
+
+        let lookahead = _mm512_castsi128_si512(_mm_cvtsi32_si128(
+            input.add(64).cast::<u32>().read_unaligned() as i32,
+        ));
+        let fourth_expanded = expand_final_window(input_block, lookahead);
+
+        let (first, first_count) = identify_expanded(first_expanded);
+        let (second, second_count) = identify_expanded(second_expanded);
+        let (third, third_count) = identify_expanded(third_expanded);
+        let (fourth, fourth_count) = identify_expanded(fourth_expanded);
+
+        let first_pair_count = first_count + second_count;
+        let second_pair_count = third_count + fourth_count;
+        let total = first_pair_count + second_pair_count;
+        if total <= 16 {
+            // Four-byte-heavy text fits one output vector, so decode it once.
+            let first_pair = combine_pair(first, first_count, second, second_count);
+            let second_pair = combine_pair(third, third_count, fourth, fourth_count);
+            let combined =
+                combine_pair(first_pair, first_pair_count, second_pair, second_pair_count);
+            let utf32 = expand_utf8_to_utf32(combined);
+            if total == 16 {
+                store_utf32_full(output, utf32);
+            } else {
+                store_utf32(output, utf32, total);
+            }
+            total
+        } else {
+            let mut output_len = write_pair(first, first_count, second, second_count, output);
+            let output = output.add(output_len);
+            output_len += write_pair(third, third_count, fourth, fourth_count, output);
+            output_len
+        }
+    }
+}
+
+#[inline(always)]
+unsafe fn convert_mixed_prefix_48(input_block: __m512i, output: *mut u32) -> usize {
+    unsafe {
+        let first_expanded = expand_window::<0>(input_block);
+        let second_expanded = expand_window::<16>(input_block);
+        let third_expanded = expand_window::<32>(input_block);
+
+        let (first, first_count) = identify_expanded(first_expanded);
+        let (second, second_count) = identify_expanded(second_expanded);
+        let output_len = write_pair(first, first_count, second, second_count, output);
+        let (third, third_count) = identify_expanded(third_expanded);
+        store_utf32(
+            output.add(output_len),
+            expand_utf8_to_utf32(third),
+            third_count,
+        );
+        output_len + third_count
+    }
+}
+
+#[inline(always)]
+unsafe fn expand_window<const START: u8>(input: __m512i) -> __m512i {
+    unsafe {
+        // VBMI gathers every 4-byte candidate substring for starts in each 16-byte window.
+        _mm512_permutexvar_epi8(window_index::<START>(), input)
+    }
+}
+
+#[inline(always)]
+unsafe fn expand_final_window(input: __m512i, lookahead: __m512i) -> __m512i {
+    unsafe { _mm512_permutex2var_epi8(input, window_index::<48>(), lookahead) }
+}
+
+#[inline(always)]
+unsafe fn window_index<const START: u8>() -> __m512i {
+    unsafe {
+        _mm512_setr_epi64(
+            byte_index_pair(START),
+            byte_index_pair(START + 2),
+            byte_index_pair(START + 4),
+            byte_index_pair(START + 6),
+            byte_index_pair(START + 8),
+            byte_index_pair(START + 10),
+            byte_index_pair(START + 12),
+            byte_index_pair(START + 14),
+        )
+    }
+}
+
+#[inline(always)]
+fn byte_index_pair(start: u8) -> i64 {
+    (start as i64)
+        | ((start as i64 + 1) << 8)
+        | ((start as i64 + 2) << 16)
+        | ((start as i64 + 3) << 24)
+        | ((start as i64 + 1) << 32)
+        | ((start as i64 + 2) << 40)
+        | ((start as i64 + 3) << 48)
+        | ((start as i64 + 4) << 56)
+}
+
+#[inline(always)]
+unsafe fn identify_expanded(expanded: __m512i) -> (__m512i, usize) {
+    unsafe {
+        let byte_class = _mm512_and_si512(expanded, _mm512_set1_epi32(0xc0));
+        let leading_bytes = _mm512_cmpneq_epu32_mask(byte_class, _mm512_set1_epi32(0x80));
+        let count = leading_bytes.count_ones() as usize;
+        (
+            _mm512_mask_compress_epi32(_mm512_setzero_si512(), leading_bytes, expanded),
+            count,
+        )
+    }
+}
+
+#[inline(always)]
+unsafe fn write_pair(
+    first: __m512i,
+    first_count: usize,
+    second: __m512i,
+    second_count: usize,
+    output: *mut u32,
+) -> usize {
+    unsafe {
+        let total = first_count + second_count;
+        if total <= 16 {
+            let combined = combine_pair(first, first_count, second, second_count);
+            store_utf32(output, expand_utf8_to_utf32(combined), total);
+        } else {
+            store_utf32(output, expand_utf8_to_utf32(first), first_count);
+            store_utf32(
+                output.add(first_count),
+                expand_utf8_to_utf32(second),
+                second_count,
+            );
+        }
+        total
+    }
+}
+
+#[inline(always)]
+unsafe fn combine_pair(
+    first: __m512i,
+    first_count: usize,
+    second: __m512i,
+    second_count: usize,
+) -> __m512i {
+    unsafe {
+        let second_mask = (((1u32 << second_count) - 1) << first_count) as __mmask16;
+        _mm512_mask_expand_epi32(first, second_mask, second)
+    }
+}
+
+#[inline(always)]
+unsafe fn store_utf32_full(output: *mut u32, utf32: __m512i) {
+    unsafe { _mm512_storeu_si512(output as *mut __m512i, utf32) }
+}
+
+#[inline(always)]
+unsafe fn store_utf32(output: *mut u32, utf32: __m512i, count: usize) {
+    unsafe { _mm512_mask_storeu_epi32(output as *mut i32, valid_lane_mask(count), utf32) }
+}
+
+#[inline(always)]
+unsafe fn expand_utf8_to_utf32(input: __m512i) -> __m512i {
+    unsafe {
+        let mut char_class = _mm512_srli_epi32::<4>(input);
+        char_class = _mm512_ternarylogic_epi32::<0xea>(
+            char_class,
+            _mm512_set1_epi32(0x0f),
+            _mm512_set1_epi32(0x80808000u32 as i32),
+        );
+
+        // Each u32 lane contains b0|b1|b2|b3 for a possible UTF-8 sequence.
+        // Rust's &str invariant gives us valid UTF-8, so this only removes
+        // prefix bits and joins payload fields into UTF-32 codepoints.
+        let mut values = _mm512_and_si512(input, _mm512_set1_epi32(0x3f3f3f7f));
+        values = _mm512_maddubs_epi16(values, _mm512_set1_epi32(0x01400140));
+        values = _mm512_madd_epi16(values, _mm512_set1_epi32(0x00011000));
+
+        let shift_left = _mm512_setr_epi64(
+            0x0707070707070707,
+            0x0b0a090900000000,
+            0x0707070707070707,
+            0x0b0a090900000000,
+            0x0707070707070707,
+            0x0b0a090900000000,
+            0x0707070707070707,
+            0x0b0a090900000000,
+        );
+        values = _mm512_sllv_epi32(values, _mm512_shuffle_epi8(shift_left, char_class));
+
+        let shift_right = _mm512_setr_epi64(
+            0x1919191919191919,
+            0x0b10151500000000,
+            0x1919191919191919,
+            0x0b10151500000000,
+            0x1919191919191919,
+            0x0b10151500000000,
+            0x1919191919191919,
+            0x0b10151500000000,
+        );
+        _mm512_srlv_epi32(values, _mm512_shuffle_epi8(shift_right, char_class))
+    }
+}
+
+#[inline(always)]
+fn valid_lane_mask(count: usize) -> __mmask16 {
+    debug_assert!(count <= 16);
+    1u32.wrapping_shl(count as u32).wrapping_sub(1) as __mmask16
+}

--- a/src/unicode/backend/mod.rs
+++ b/src/unicode/backend/mod.rs
@@ -1,0 +1,57 @@
+use std::fmt::Debug;
+
+#[cfg(target_arch = "x86_64")]
+mod avx;
+#[cfg(target_arch = "x86_64")]
+mod avx512;
+mod scalar;
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) use avx::Utf8ToUtf32AVX2;
+#[cfg(target_arch = "x86_64")]
+pub(crate) use avx512::Utf8ToUtf32AVX512;
+pub(crate) use scalar::Utf8ToUtf32Scalar;
+
+pub(crate) trait Backend: Sized + Debug + Clone + 'static {
+    fn is_available() -> bool;
+
+    /// # Safety
+    /// The backend's target features must be enabled at the call site.
+    unsafe fn convert_into(input: &str, out: &mut Vec<u32>);
+}
+
+#[cfg(all(feature = "benching", target_arch = "x86_64"))]
+#[inline(always)]
+pub fn avx512_is_available() -> bool {
+    Utf8ToUtf32AVX512::is_available()
+}
+
+#[cfg(all(feature = "benching", target_arch = "x86_64"))]
+#[inline(always)]
+pub fn avx2_is_available() -> bool {
+    Utf8ToUtf32AVX2::is_available()
+}
+
+#[cfg(all(feature = "benching", target_arch = "x86_64"))]
+#[inline(always)]
+pub unsafe fn convert_avx512_into(input: &str, out: &mut Vec<u32>) {
+    unsafe {
+        Utf8ToUtf32AVX512::convert_into(input, out);
+    }
+}
+
+#[cfg(all(feature = "benching", target_arch = "x86_64"))]
+#[inline(always)]
+pub unsafe fn convert_avx2_into(input: &str, out: &mut Vec<u32>) {
+    unsafe {
+        Utf8ToUtf32AVX2::convert_into(input, out);
+    }
+}
+
+#[cfg(feature = "benching")]
+#[inline(always)]
+pub fn convert_scalar_into(input: &str, out: &mut Vec<u32>) {
+    unsafe {
+        Utf8ToUtf32Scalar::convert_into(input, out);
+    }
+}

--- a/src/unicode/backend/scalar.rs
+++ b/src/unicode/backend/scalar.rs
@@ -1,0 +1,18 @@
+use super::Backend;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Utf8ToUtf32Scalar;
+
+impl Backend for Utf8ToUtf32Scalar {
+    #[inline(always)]
+    fn is_available() -> bool {
+        true
+    }
+
+    #[inline(always)]
+    unsafe fn convert_into(input: &str, out: &mut Vec<u32>) {
+        out.clear();
+        out.reserve(input.len());
+        out.extend(input.chars().map(|c| c as u32));
+    }
+}

--- a/src/unicode/mod.rs
+++ b/src/unicode/mod.rs
@@ -1,0 +1,287 @@
+//! UTF-8 preprocessing for future Unicode-aware matching.
+//!
+//! The matcher still operates on bytes today. This module only prepares the
+//! UTF-32 representation that a future Unicode prefilter and Smith-Waterman
+//! path can consume.
+
+#![allow(dead_code)]
+
+#[cfg(feature = "benching")]
+pub mod backend;
+#[cfg(not(feature = "benching"))]
+pub(crate) mod backend;
+
+use backend::{Backend, Utf8ToUtf32Scalar};
+
+#[cfg(target_arch = "x86_64")]
+use backend::{Utf8ToUtf32AVX2, Utf8ToUtf32AVX512};
+
+/// Reusable UTF-8 preprocessing state.
+///
+/// Construction performs runtime backend detection once. Each call to
+/// [`Unicode::prepare`] then reuses the owned UTF-32 buffer, replacing its
+/// previous contents with the input's codepoints.
+#[derive(Debug, Clone)]
+pub struct Unicode {
+    backend: UnicodeBackend,
+    codepoints: Vec<u32>,
+}
+
+impl Default for Unicode {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Unicode {
+    pub fn new() -> Self {
+        Self {
+            backend: UnicodeBackend::detect(),
+            codepoints: Vec::new(),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            backend: UnicodeBackend::detect(),
+            codepoints: Vec::with_capacity(capacity),
+        }
+    }
+
+    #[cfg(any(test, feature = "fuzzing", feature = "benching"))]
+    pub fn new_scalar() -> Self {
+        Self {
+            backend: UnicodeBackend::Scalar,
+            codepoints: Vec::new(),
+        }
+    }
+
+    #[cfg(any(test, feature = "fuzzing", feature = "benching"))]
+    pub fn new_scalar_with_capacity(capacity: usize) -> Self {
+        Self {
+            backend: UnicodeBackend::Scalar,
+            codepoints: Vec::with_capacity(capacity),
+        }
+    }
+
+    #[inline(always)]
+    pub fn needs_unicode(&self, needle: &str) -> bool {
+        !needle.is_ascii()
+    }
+
+    #[inline(always)]
+    pub fn prepare(&mut self, input: &str) -> &[u32] {
+        unsafe {
+            self.backend.convert_into(input, &mut self.codepoints);
+        }
+        &self.codepoints
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum UnicodeBackend {
+    #[cfg(target_arch = "x86_64")]
+    AVX512,
+    #[cfg(target_arch = "x86_64")]
+    AVX2,
+    Scalar,
+}
+
+impl UnicodeBackend {
+    fn detect() -> Self {
+        #[cfg(target_arch = "x86_64")]
+        {
+            if Utf8ToUtf32AVX512::is_available() {
+                return Self::AVX512;
+            }
+            if Utf8ToUtf32AVX2::is_available() {
+                return Self::AVX2;
+            }
+        }
+
+        Self::Scalar
+    }
+
+    #[inline(always)]
+    unsafe fn convert_into(self, input: &str, out: &mut Vec<u32>) {
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::AVX512 => unsafe {
+                Utf8ToUtf32AVX512::convert_into(input, out);
+            },
+            #[cfg(target_arch = "x86_64")]
+            Self::AVX2 => unsafe {
+                Utf8ToUtf32AVX2::convert_into(input, out);
+            },
+            Self::Scalar => unsafe {
+                Utf8ToUtf32Scalar::convert_into(input, out);
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bolero::check;
+
+    #[test]
+    fn unicode_detection_only_depends_on_non_ascii() {
+        let unicode = Unicode::new();
+        assert!(!unicode.needs_unicode(""));
+        assert!(!unicode.needs_unicode("abcXYZ012/_-"));
+        assert!(unicode.needs_unicode("cafe\u{301}"));
+        assert!(unicode.needs_unicode("\u{6771}\u{4eac}"));
+        assert!(unicode.needs_unicode("hello \u{1f600}"));
+    }
+
+    #[test]
+    fn converts_manual_cases() {
+        for input in [
+            "",
+            "abc",
+            "01234567890123456789012345678901",
+            "012345678901234567890123456789012",
+            "\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}",
+            "\u{416}\u{416}\u{416}\u{416}\u{416}\u{416}\u{416}\u{416}",
+            "\u{6771}\u{4eac}\u{6771}\u{4eac}\u{6771}\u{4eac}\u{6771}\u{4eac}",
+            "\u{1f600}\u{1f600}\u{1f600}\u{1f600}",
+            "a\u{e9}b\u{416}c\u{6771}d\u{1f600}e",
+            "0123456789012345678901234567890\u{e9}",
+            "\u{e9}0123456789012345678901234567890",
+            "abc\u{e9}\u{416}\u{6771}\u{4eac}\u{1f600}xyz",
+        ] {
+            assert_converts(input);
+        }
+    }
+
+    #[test]
+    fn reusable_buffer_replaces_previous_contents() {
+        let mut unicode = Unicode::new();
+        assert_eq!(unicode.prepare("abcdef"), &[97, 98, 99, 100, 101, 102]);
+        assert_eq!(
+            unicode.prepare("\u{e9}\u{6771}\u{1f600}"),
+            &[0xe9, 0x6771, 0x1f600]
+        );
+        assert!(unicode.prepare("").is_empty());
+    }
+
+    #[test]
+    fn randomized_valid_utf8_matches_chars() {
+        check!()
+            .with_iterations(if cfg!(miri) { 4 } else { 256 })
+            .with_max_len(if cfg!(miri) { 128 } else { 4096 })
+            .for_each(|input: &[u8]| {
+                let text = generated_string(input, 256);
+                assert_converts(&text);
+            });
+    }
+
+    fn assert_converts(input: &str) {
+        let want = input.chars().map(|c| c as u32).collect::<Vec<_>>();
+
+        let mut unicode = Unicode::new();
+        let got = unicode.prepare(input);
+        assert_eq!(
+            got,
+            want.as_slice(),
+            "runtime conversion mismatch for {input:?}"
+        );
+
+        let mut scalar = Unicode::new_scalar();
+        let scalar = scalar.prepare(input);
+        assert_eq!(
+            scalar,
+            want.as_slice(),
+            "scalar conversion mismatch for {input:?}"
+        );
+
+        #[cfg(target_arch = "x86_64")]
+        if Utf8ToUtf32AVX512::is_available() {
+            let mut avx512 = Vec::new();
+            unsafe {
+                Utf8ToUtf32AVX512::convert_into(input, &mut avx512);
+            }
+            assert_eq!(avx512, want, "AVX-512 conversion mismatch for {input:?}");
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        if Utf8ToUtf32AVX2::is_available() {
+            let mut avx2 = Vec::new();
+            unsafe {
+                Utf8ToUtf32AVX2::convert_into(input, &mut avx2);
+            }
+            assert_eq!(avx2, want, "AVX2 conversion mismatch for {input:?}");
+        }
+    }
+
+    fn generated_string(input: &[u8], max_chars: usize) -> String {
+        let mut cursor = ByteCursor::new(input);
+        let len = cursor.len(
+            max_chars,
+            &[0, 1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 63, 64, 127],
+        );
+        (0..len).map(|_| cursor.char()).collect()
+    }
+
+    struct ByteCursor<'a> {
+        input: &'a [u8],
+        pos: usize,
+    }
+
+    impl<'a> ByteCursor<'a> {
+        fn new(input: &'a [u8]) -> Self {
+            Self { input, pos: 0 }
+        }
+
+        fn next(&mut self) -> u8 {
+            let byte = if self.input.is_empty() {
+                (self.pos as u8).wrapping_mul(31).wrapping_add(17)
+            } else {
+                self.input[self.pos % self.input.len()]
+                    .wrapping_add(((self.pos / self.input.len()) as u8).wrapping_mul(23))
+            };
+            self.pos += 1;
+            byte
+        }
+
+        fn usize(&mut self) -> usize {
+            let mut value = 0usize;
+            for shift in (0..usize::BITS as usize).step_by(8) {
+                value |= (self.next() as usize) << shift;
+            }
+            value
+        }
+
+        fn len(&mut self, max: usize, boundaries: &[usize]) -> usize {
+            if self.next() % 4 == 0 {
+                boundaries[(self.next() as usize) % boundaries.len()].min(max)
+            } else {
+                self.usize() % (max + 1)
+            }
+        }
+
+        fn char(&mut self) -> char {
+            match self.next() % 24 {
+                0 => '\0',
+                1 => ' ',
+                2 => '/',
+                3 => '.',
+                4 => '_',
+                5 => '-',
+                6..=9 => (b'a' + (self.next() % 26)) as char,
+                10..=12 => (b'A' + (self.next() % 26)) as char,
+                13..=14 => (b'0' + (self.next() % 10)) as char,
+                15 => '\u{e9}',
+                16 => '\u{df}',
+                17 => '\u{416}',
+                18 => '\u{3a9}',
+                19 => '\u{4e2d}',
+                20 => '\u{6771}',
+                21 => '\u{301}',
+                22 => '\u{1f600}',
+                _ => '\u{1f680}',
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, we only match on bytes directly which works fine for ASCII needles on ascii/utf-8 haystacks, since 0-128 are reserved for ascii in unicode so they'll never match. When the needle contains UTF-8 codepoints, the simplest way to add support would be converting to UTF-32 and match on that instead. This reduces our SIMD lanes by 1/4, so ideally we have specialized prefilter paths to handle unicode needles with expanding every byte to 32-bit.

I'm imagining a flow like:
- Detect unicode needle
- Route to specialized prefilter
- Expand UTF-8 -> UTF-32
- Smith Waterman

For the expansion of UTF-8 -> UTF-32, `simdutf` provides reference implementations for AVX2, AVX-512, NEON, SSE and provides ~2-3x speed-up over Rust's built-in conversion via `haystack.chars().map(|c| c as u32)`. 

|                | `AVX-512`               | `AVX2`                          | `simdutf`                       | `Scalar`                          |
|:---------------|:------------------------|:--------------------------------|:--------------------------------|:--------------------------------- |
| **`Arabic`**   | `5.84 us` (**1.00x**) | `16.13 us` (*2.76x slower*)   | `8.14 us` (*1.39x slower*)    | `21.26 us` (*3.64x slower*)     |
| **`Chinese`**  | `4.60 us` (**1.00x**) | `4.35 us` (**1.06x faster**)  | `6.68 us` (*1.45x slower*)    | `15.47 us` (*3.36x slower*)     |
| **`Emoji`**    | `3.63 us` (**1.00x**) | `3.32 us` (**1.09x faster**)  | `5.95 us` (*1.64x slower*)    | `13.38 us` (*3.69x slower*)     |
| **`Hebrew`**   | `4.79 us` (**1.00x**) | `12.93 us` (*2.70x slower*)   | `6.67 us` (*1.39x slower*)    | `17.18 us` (*3.59x slower*)     |
| **`Hindi`**    | `5.46 us` (**1.00x**) | `37.42 us` (*6.85x slower*)   | `8.00 us` (*1.46x slower*)    | `19.65 us` (*3.60x slower*)     |
| **`Japanese`** | `4.24 us` (**1.00x**) | `7.91 us` (*1.87x slower*)    | `6.18 us` (*1.46x slower*)    | `16.06 us` (*3.79x slower*)     |
| **`Korean`**   | `4.13 us` (**1.00x**) | `34.58 us` (*8.38x slower*)   | `6.10 us` (*1.48x slower*)    | `14.83 us` (*3.59x slower*)     |
| **`Latin`**    | `1.72 us` (**1.00x**) | `1.88 us` (**1.10x slower**)  | `1.78 us` (**1.04x slower**)  | `32.68 us` (*19.03x slower*)    |
| **`Russian`**  | `7.66 us` (**1.00x**) | `19.48 us` (*2.54x slower*)   | `10.43 us` (*1.36x slower*)   | `27.05 us` (*3.53x slower*)     |


For handling casing, each character must map to exactly one character, meaning cases like `ß -> ss` will not be treated correctly. This is an edge case though that should significantly simplify the code. Likewise, the capitalization bonus will only apply to ASCII.

Closes #81 