### PR TITLE
feat: prefix, suffix, substring, exact matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For commercial support, please [contact me](mailto:frizbee@liam.super.fish). I'd
 See [the docs](https://docs.rs/frizbee) for more usage examples.
 
 ```rust
-use frizbee::{match_list, match_list_parallel, Config};
+use frizbee::{match_list, match_list_parallel, Config, Matching};
 
 let needle = "fBr";
 let haystacks = ["fooBar", "foo_bar", "prelude", "println!"];
@@ -19,6 +19,8 @@ let haystacks = ["fooBar", "foo_bar", "prelude", "println!"];
 let matches = match_list(needle, &haystacks, &Config::default());
 // or in parallel (8 threads)
 let matches = match_list_parallel(needle, &haystacks, &Config::default(), 8);
+// or use a non-fuzzy matching mode (exact, prefix, suffix, substring)
+let matches = match_list(needle, &haystacks, &Config::default().matching(Matching::Substring));
 ```
 
 or use the slightly slower `fuzzy_match` iterator API
@@ -175,7 +177,7 @@ The parallel implementation uses work-stealing to distribute the work across thr
 
 ### Unicode
 
-Frizbee matches against UTF-8 bytes directly rather than converting to UTF-32 codepoints like Nucleo. This results in near-native performance without preprocessing or any extra memory usage. By default, with `config.unicode = UnicodeMatching::Smart`, the unicode path will only be taken when the needle contains non-ASCII characters.
+Frizbee matches against UTF-8 bytes directly rather than converting to UTF-32 codepoints like Nucleo. This results in near-native performance without preprocessing or any extra memory usage. By default, `Config::default()` uses `UnicodeMatching::Smart`, so the unicode path will only be taken when the needle contains non-ASCII characters.
 
 #### Prefiltering
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For commercial support, please [contact me](mailto:frizbee@liam.super.fish). I'd
 See [the docs](https://docs.rs/frizbee) for more usage examples.
 
 ```rust
-use frizbee::{match_list, match_list_parallel, Config, Matching};
+use frizbee::{match_list, match_list_parallel, Config};
 
 let needle = "fBr";
 let haystacks = ["fooBar", "foo_bar", "prelude", "println!"];
@@ -19,8 +19,9 @@ let haystacks = ["fooBar", "foo_bar", "prelude", "println!"];
 let matches = match_list(needle, &haystacks, &Config::default());
 // or in parallel (8 threads)
 let matches = match_list_parallel(needle, &haystacks, &Config::default(), 8);
-// or use a non-fuzzy matching mode (exact, prefix, suffix, substring)
-let matches = match_list(needle, &haystacks, &Config::default().matching(Matching::Substring));
+// or use a matching mode (fuzzy, substring, prefix, suffix, exact) based on the query
+// syntax, e.g. foo, 'foo, ^foo, foo$, ^foo$
+let matches = Matcher::from_query(needle).match_list(&haystacks);
 ```
 
 or use the slightly slower `fuzzy_match` iterator API

--- a/benches/match_list/mod.rs
+++ b/benches/match_list/mod.rs
@@ -95,6 +95,7 @@ fn match_list_bench_impl(
             BenchmarkInput::SequentialAndParallel { .. } => BenchmarkId::new(name, "Sequential"),
         }
     };
+    let is_sequential_and_parallel = matches!(input, BenchmarkInput::SequentialAndParallel { .. });
 
     group.throughput(criterion::Throughput::Bytes(size as u64));
 
@@ -129,10 +130,13 @@ fn match_list_bench_impl(
             matches
         })
     });
-    group.bench_with_input(benchmark_id("Substring"), haystack, |b, haystack| {
-        let mut matcher = Matcher::new(needle, &Config::default().matching(Matching::Substring));
-        b.iter(|| matcher.match_list(black_box(haystack)))
-    });
+    if is_sequential_and_parallel {
+        group.bench_with_input(benchmark_id("Substring"), haystack, |b, haystack| {
+            let mut matcher =
+                Matcher::new(needle, &Config::default().matching(Matching::Substring));
+            b.iter(|| matcher.match_list(black_box(haystack)))
+        });
+    }
     group.bench_with_input(benchmark_id("All Scores"), haystack, |b, haystack| {
         let mut matcher = Matcher::new(needle, &Config::default().max_typos(None));
         b.iter(|| matcher.match_list(black_box(haystack)))
@@ -180,6 +184,15 @@ fn match_list_bench_impl(
             BenchmarkId::new("Frizbee", "Parallel (x8)"),
             haystack,
             |b, haystack| b.iter(|| match_list_parallel(needle, haystack, Some(0))),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("Substring", "Parallel (x8)"),
+            haystack,
+            |b, haystack| {
+                let mut matcher =
+                    Matcher::new(needle, &Config::default().matching(Matching::Substring));
+                b.iter(|| matcher.match_list_parallel(haystack, 8))
+            },
         );
         group.bench_with_input(
             BenchmarkId::new("All Scores", "Parallel (x8)"),

--- a/benches/match_list/mod.rs
+++ b/benches/match_list/mod.rs
@@ -130,53 +130,23 @@ fn match_list_bench_impl(
         })
     });
     group.bench_with_input(benchmark_id("Substring"), haystack, |b, haystack| {
-        let mut matcher = Matcher::new(
-            needle,
-            &Config {
-                matching: Matching::Substring,
-                ..Default::default()
-            },
-        );
+        let mut matcher = Matcher::new(needle, &Config::default().matching(Matching::Substring));
         b.iter(|| matcher.match_list(black_box(haystack)))
     });
     group.bench_with_input(benchmark_id("All Scores"), haystack, |b, haystack| {
-        let mut matcher = Matcher::new(
-            needle,
-            &Config {
-                max_typos: None,
-                ..Default::default()
-            },
-        );
+        let mut matcher = Matcher::new(needle, &Config::default().max_typos(None));
         b.iter(|| matcher.match_list(black_box(haystack)))
     });
     group.bench_with_input(benchmark_id("1 Typo"), haystack, |b, haystack| {
-        let mut matcher = Matcher::new(
-            needle,
-            &Config {
-                max_typos: Some(1),
-                ..Default::default()
-            },
-        );
+        let mut matcher = Matcher::new(needle, &Config::default().max_typos(Some(1)));
         b.iter(|| matcher.match_list(black_box(haystack)))
     });
     group.bench_with_input(benchmark_id("2 Typos"), haystack, |b, haystack| {
-        let mut matcher = Matcher::new(
-            needle,
-            &Config {
-                max_typos: Some(2),
-                ..Default::default()
-            },
-        );
+        let mut matcher = Matcher::new(needle, &Config::default().max_typos(Some(2)));
         b.iter(|| matcher.match_list(black_box(haystack)))
     });
     group.bench_with_input(benchmark_id("3 Typos"), haystack, |b, haystack| {
-        let mut matcher = Matcher::new(
-            needle,
-            &Config {
-                max_typos: Some(3),
-                ..Default::default()
-            },
-        );
+        let mut matcher = Matcher::new(needle, &Config::default().max_typos(Some(3)));
         b.iter(|| matcher.match_list(black_box(haystack)))
     });
 
@@ -239,13 +209,11 @@ fn match_list_parallel(
     haystack: &[&str],
     max_typos: Option<u16>,
 ) -> Vec<frizbee::Match> {
+    let config = Config::default().max_typos(max_typos);
     frizbee::match_list_parallel(
         black_box(needle),
         black_box(haystack),
-        black_box(&Config {
-            max_typos,
-            ..Default::default()
-        }),
+        black_box(&config),
         8,
     )
 }

--- a/benches/match_list/mod.rs
+++ b/benches/match_list/mod.rs
@@ -1,5 +1,5 @@
 use criterion::BenchmarkId;
-use frizbee::{Config, Matcher, radix_sort_matches};
+use frizbee::{Config, Matcher, Matching, radix_sort_matches};
 use std::{
     hint::black_box,
     sync::Arc,
@@ -128,6 +128,16 @@ fn match_list_bench_impl(
             radix_sort_matches(&mut matches);
             matches
         })
+    });
+    group.bench_with_input(benchmark_id("Substring"), haystack, |b, haystack| {
+        let mut matcher = Matcher::new(
+            needle,
+            &Config {
+                matching: Matching::Substring,
+                ..Default::default()
+            },
+        );
+        b.iter(|| matcher.match_list(black_box(haystack)))
     });
     group.bench_with_input(benchmark_id("All Scores"), haystack, |b, haystack| {
         let mut matcher = Matcher::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,44 @@ impl Default for Config {
     }
 }
 
+impl Config {
+    /// Sets the matching mode
+    pub fn matching(mut self, matching: Matching) -> Self {
+        self.matching = matching;
+        self
+    }
+
+    /// Sets the maximum number of typos allowed
+    pub fn max_typos(mut self, max_typos: Option<u16>) -> Self {
+        self.max_typos = max_typos;
+        self
+    }
+
+    /// Sets the casing mode
+    pub fn casing(mut self, casing: CaseMatching) -> Self {
+        self.casing = casing;
+        self
+    }
+
+    /// Sets the unicode mode
+    pub fn unicode(mut self, unicode: UnicodeMatching) -> Self {
+        self.unicode = unicode;
+        self
+    }
+
+    /// Sets whether to sort the results
+    pub fn sort(mut self, sort: bool) -> Self {
+        self.sort = sort;
+        self
+    }
+
+    /// Sets the scoring
+    pub fn scoring(mut self, scoring: Scoring) -> Self {
+        self.scoring = scoring;
+        self
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CaseMatching {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ use serde::{Deserialize, Serialize};
 
 mod r#const;
 mod k_merge;
+mod literal;
 mod matcher;
 mod prefilter;
 mod smith_waterman;
@@ -129,6 +130,7 @@ pub fn match_list_parallel<S1: AsRef<str>, S2: AsRef<str> + Sync>(
     Matcher::new(needle.as_ref(), config).match_list_parallel(haystacks, threads)
 }
 
+/// Result of a fuzzy match, containing the score and index in the haystack
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Match {
@@ -175,6 +177,8 @@ impl PartialEq for Match {
 }
 impl Eq for Match {}
 
+/// Like [`Match`] but includes the indices of the chars in the haystack that matched the needle in
+/// reverse order
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MatchIndices {
@@ -231,6 +235,11 @@ pub struct Config {
     /// Controls how unicode is handled while matching.
     #[cfg_attr(feature = "serde", serde(default))]
     pub unicode: UnicodeMatching,
+    /// Selects the matching algorithm: fuzzy (Smith-Waterman) or one of the literal modes
+    /// (exact, prefix, suffix, substring). Literal modes require the needle to appear as a
+    /// contiguous run of characters and do not support typos (`max_typos` is ignored).
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub matching: Matching,
     /// Sort the results by score (descending)
     pub sort: bool,
     /// Controls the scoring used by the smith waterman algorithm. You may tweak these but pay
@@ -245,6 +254,7 @@ impl Default for Config {
             max_typos: Some(0),
             casing: CaseMatching::Ignore,
             unicode: UnicodeMatching::Smart,
+            matching: Matching::Fuzzy,
             sort: true,
             scoring: Scoring::default(),
         }
@@ -298,6 +308,39 @@ impl UnicodeMatching {
     }
 }
 
+/// Selects the matching algorithm
+///
+/// [`Matching::Fuzzy`] uses the Smith-Waterman algorithm (with typos, gaps and substitutions)
+/// [`Matching::Exact`] matches the haystack exactly
+/// [`Matching::Prefix`] matches the haystack if it starts with the needle
+/// [`Matching::Suffix`] matches the haystack if it ends with the needle
+/// [`Matching::Substring`] matches the haystack if it contains the needle
+///
+/// Only the [`Matching::Fuzzy`] mode supports typos
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum Matching {
+    /// Smith-Waterman fuzzy matching (the default)
+    #[default]
+    Fuzzy,
+    /// The haystack must equal the needle
+    Exact,
+    /// The haystack must start with the needle
+    Prefix,
+    /// The haystack must end with the needle
+    Suffix,
+    /// The needle must appear somewhere in the haystack. When it appears more than once, the
+    /// highest-scoring occurrence is used, preferring earlier matches on tie
+    Substring,
+}
+
+impl Matching {
+    #[inline(always)]
+    pub(crate) fn is_fuzzy(self) -> bool {
+        matches!(self, Matching::Fuzzy)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
@@ -339,5 +382,19 @@ impl Default for Scoring {
             exact_match_bonus: EXACT_MATCH_BONUS,
             delimiter_bonus: DELIMITER_BONUS,
         }
+    }
+}
+
+impl Scoring {
+    /// Panics if a needle of `needle_len` bytes could overflow the `u16` score. `max_bonus_per_char`
+    /// is the largest bonus a single matched character can add on top of `match_score`; it differs
+    /// between the fuzzy and literal scorers, so each passes its own.
+    pub(crate) fn guard_against_score_overflow(&self, needle_len: usize, max_bonus_per_char: u16) {
+        let max_per_char = self.match_score + max_bonus_per_char;
+        let max_needle_len = (u16::MAX - self.prefix_bonus - self.exact_match_bonus) / max_per_char;
+        assert!(
+            needle_len <= max_needle_len as usize,
+            "needle too long and could overflow the u16 score: {needle_len} > {max_needle_len}"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,10 @@
 //! let haystacks = ["fooBar", "foo_bar", "prelude", "println!"];
 //!
 //! let mut matcher = Matcher::new(needle, &Config::default());
+//! // or use a matching mode (fuzzy, substring, prefix, suffix, exact) based on the query
+//! // syntax, e.g. foo, 'foo, ^foo, foo$, ^foo$
+//! let mut matcher = Matcher::from_query(needle);
+//!
 //! let matches = matcher.match_list(&haystacks);
 //! ```
 //!

--- a/src/literal/algo.rs
+++ b/src/literal/algo.rs
@@ -1,0 +1,325 @@
+use super::rank::rare_byte_offsets;
+use crate::prefilter::algo::load_window;
+use crate::prefilter::backend::{Backend, BitMaskOps};
+use crate::prefilter::{UnicodeChar, case_needle, case_needle_unicode};
+use crate::{Config, Match, MatchIndices, Matching, Scoring};
+
+/// Literal matching: exact / prefix / suffix / substring
+/// Specialized for one SIMD [`crate::prefilter::backend::Backend`] supporting both ASCII and Unicode
+/// Identical scoring to Smith-Waterman
+#[derive(Debug, Clone)]
+pub(crate) struct LiteralImpl<B: Backend> {
+    mode: Matching,
+    scoring: Scoring,
+    needle_len: usize,
+    /// Per-byte `(original, opposite-case)` bytes for ASCII case-insensitive matching
+    needle_ascii: Vec<(u8, u8)>,
+    /// Per-codepoint needle, read only on the unicode path. Holds each character's UTF-8 bytes and
+    /// its opposite-case bytes, used for whole-codepoint case-insensitive matching
+    needle_unicode: Vec<UnicodeChar>,
+    /// Needle byte offsets of the two rarest bytes, `seed_a_off <= seed_b_off`, chosen as the two
+    /// rarest bytes (see [`rare_byte_offsets`])
+    seed_a_off: usize,
+    seed_b_off: usize,
+    /// Splatted `(original, opposite-case)` bytes at `seed_a_off` / `seed_b_off`, the two scan seeds
+    seed_a: (B::Chunk, B::Chunk),
+    seed_b: (B::Chunk, B::Chunk),
+}
+
+impl<B: Backend> LiteralImpl<B> {
+    /// # Safety
+    /// The backend's target features must be enabled.
+    #[inline(always)]
+    pub(crate) unsafe fn new(needle: &str, config: &Config) -> Self {
+        Self::guard_against_score_overflow(needle.len(), &config.scoring);
+
+        let case_sensitive = config.casing.respects_case_for(needle);
+        let unicode = config.unicode.respects_unicode_for(needle);
+        let needle_ascii = case_needle(needle.as_bytes(), case_sensitive);
+        let needle_unicode = case_needle_unicode(needle, case_sensitive);
+
+        // Per-byte `(original, opposite-case)` pairs used to splat the prefilter seeds. On the
+        // unicode path this flattens each codepoint's bytes; on the ASCII path it is `needle_ascii`.
+        let seed_bytes: Vec<(u8, u8)> = if unicode {
+            needle_unicode
+                .iter()
+                .flat_map(|c| (0..c.len).map(|i| (c.chars[i], c.flipped_chars[i])))
+                .collect()
+        } else {
+            needle_ascii.clone()
+        };
+
+        // Seed the two-byte prefilter on the two rarest needle bytes. A single-byte (or empty)
+        // needle has no pair, so both seeds collapse onto offset 0.
+        let (seed_a_off, seed_b_off) = if seed_bytes.len() >= 2 {
+            rare_byte_offsets(needle.as_bytes())
+        } else {
+            (0, 0)
+        };
+        let splat = |off: usize| {
+            // Falls back to (0, 0) only for an empty needle, which never reaches the match methods
+            let (orig, flipped) = seed_bytes.get(off).copied().unwrap_or_default();
+            unsafe { (B::splat(orig), B::splat(flipped)) }
+        };
+        let seed_a = splat(seed_a_off);
+        let seed_b = splat(seed_b_off);
+
+        Self {
+            mode: config.matching,
+            scoring: config.scoring.clone(),
+            needle_len: needle.len(),
+            needle_ascii,
+            needle_unicode,
+            seed_a_off,
+            seed_b_off,
+            seed_a,
+            seed_b,
+        }
+    }
+
+    pub(crate) fn is_available() -> bool {
+        B::is_available()
+    }
+
+    #[inline(always)]
+    pub(super) unsafe fn match_list_impl<const UNICODE: bool, H: AsRef<str>>(
+        &self,
+        haystacks: &[H],
+        haystack_index_offset: u32,
+        matches: &mut Vec<Match>,
+    ) {
+        for (index, haystack) in (haystack_index_offset..).zip(haystacks.iter()) {
+            if let Some(m) = unsafe { self.match_one_impl::<UNICODE, &H>(haystack, index) } {
+                matches.push(m);
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub(super) unsafe fn match_one_impl<const UNICODE: bool, H: AsRef<str>>(
+        &self,
+        haystack: H,
+        index: u32,
+    ) -> Option<Match> {
+        let haystack = haystack.as_ref().as_bytes();
+        let (pos, score) = unsafe { self.find::<UNICODE>(haystack) }?;
+        let exact = pos == 0 && self.needle_len == haystack.len();
+        Some(Match {
+            index,
+            score,
+            exact,
+            #[cfg(feature = "match_end_col")]
+            end_col: (pos + self.needle_len)
+                .saturating_sub(1)
+                .min(u16::MAX as usize) as u16,
+        })
+    }
+
+    #[inline(always)]
+    pub(super) unsafe fn match_list_indices_impl<const UNICODE: bool, H: AsRef<str>>(
+        &self,
+        haystacks: &[H],
+    ) -> Vec<MatchIndices> {
+        let mut matches = vec![];
+        for (index, haystack) in haystacks.iter().enumerate() {
+            if let Some(m) =
+                unsafe { self.match_one_indices_impl::<UNICODE, &H>(haystack, index as u32) }
+            {
+                matches.push(m);
+            }
+        }
+        matches
+    }
+
+    #[inline(always)]
+    pub(super) unsafe fn match_one_indices_impl<const UNICODE: bool, H: AsRef<str>>(
+        &self,
+        haystack: H,
+        index: u32,
+    ) -> Option<MatchIndices> {
+        let haystack = haystack.as_ref().as_bytes();
+        let (pos, score) = unsafe { self.find::<UNICODE>(haystack) }?;
+        let exact = pos == 0 && self.needle_len == haystack.len();
+        // Every byte of the matched run is a matched index, but add in reverse order to match
+        // the fuzzy matcher implementation
+        let indices = (pos..pos + self.needle_len).rev().collect();
+        Some(MatchIndices {
+            index,
+            score,
+            exact,
+            indices,
+        })
+    }
+
+    /// Verifies that the needle matches the haystack starting at byte `pos`
+    #[inline(always)]
+    fn matches_at<const UNICODE: bool>(&self, haystack: &[u8], pos: usize) -> bool {
+        if UNICODE {
+            let mut k = pos;
+            for c in &self.needle_unicode {
+                let bytes = &haystack[k..k + c.len];
+                if bytes != &c.chars[..c.len] && bytes != &c.flipped_chars[..c.len] {
+                    return false;
+                }
+                k += c.len;
+            }
+        } else {
+            for (k, &(orig, flipped)) in self.needle_ascii.iter().enumerate() {
+                let byte = haystack[pos + k];
+                if byte != orig && byte != flipped {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Score contribution of a single matched scalar whose start byte is at haystack index `start`.
+    /// `matched_exact_case` is true when the haystack scalar equals the needle's original case.
+    #[inline(always)]
+    fn score_scalar(&self, haystack: &[u8], start: usize, matched_exact_case: bool) -> u16 {
+        let s = &self.scoring;
+        let mut score = s.match_score;
+        if matched_exact_case {
+            score += s.matching_case_bonus;
+        }
+        if start == 0 {
+            score += s.prefix_bonus;
+        } else {
+            let byte = haystack[start];
+            let prev = haystack[start - 1];
+            if byte.is_ascii_uppercase() && prev.is_ascii_lowercase() {
+                score += s.capitalization_bonus;
+            }
+            if is_delimiter(prev) && !is_delimiter(byte) {
+                score += s.delimiter_bonus;
+            }
+        }
+        score
+    }
+
+    /// Scores a contiguous match at byte `pos`, summing one [`Self::score_scalar`] per needle
+    /// scalar: a byte on the ASCII path or a codepoint on the unicode path
+    #[inline(always)]
+    fn score_at<const UNICODE: bool>(&self, haystack: &[u8], pos: usize) -> u16 {
+        let mut score = 0u16;
+        if UNICODE {
+            let mut start = pos;
+            for c in &self.needle_unicode {
+                let matched_exact_case = haystack[start..start + c.len] == c.chars[..c.len];
+                score += self.score_scalar(haystack, start, matched_exact_case);
+                start += c.len;
+            }
+        } else {
+            for (k, &(orig, _)) in self.needle_ascii.iter().enumerate() {
+                let start = pos + k;
+                score += self.score_scalar(haystack, start, haystack[start] == orig);
+            }
+        }
+
+        if pos == 0 && self.needle_len == haystack.len() {
+            score += self.scoring.exact_match_bonus;
+        }
+        score
+    }
+
+    /// Returns the matched byte position (start) if the haystack matches under the configured mode
+    /// as well as the score.
+    /// For substring, it checks all positions to find the best-score, preferring earlier matches
+    /// when tied.
+    #[inline(always)]
+    unsafe fn find<const UNICODE: bool>(&self, haystack: &[u8]) -> Option<(usize, u16)> {
+        let needle_len = self.needle_len;
+        if haystack.len() < needle_len {
+            return None;
+        }
+
+        match self.mode {
+            Matching::Fuzzy => unreachable!("fuzzy matching does not use the literal backend"),
+            Matching::Exact => (haystack.len() == needle_len
+                && self.matches_at::<UNICODE>(haystack, 0))
+            .then(|| (0, self.score_at::<UNICODE>(haystack, 0))),
+            Matching::Prefix => self
+                .matches_at::<UNICODE>(haystack, 0)
+                .then(|| (0, self.score_at::<UNICODE>(haystack, 0))),
+            Matching::Suffix => {
+                let pos = haystack.len() - needle_len;
+                self.matches_at::<UNICODE>(haystack, pos)
+                    .then(|| (pos, self.score_at::<UNICODE>(haystack, pos)))
+            }
+            Matching::Substring => unsafe { self.find_substring::<UNICODE>(haystack) },
+        }
+    }
+
+    /// Two-byte SIMD prefilter (similar to `memchr::memmem`)
+    ///
+    /// Scan the string for both seed bytes (the two rarest bytes from the needle), and on a match,
+    /// perform a scalar scan for the rest of the needle.
+    #[inline(always)]
+    unsafe fn find_substring<const UNICODE: bool>(&self, haystack: &[u8]) -> Option<(usize, u16)> {
+        let len = haystack.len();
+        let needle_len = self.needle_len;
+        debug_assert!(needle_len > 0, "empty needles are handled by the caller");
+        let last_start = len - needle_len + 1;
+
+        let mut best: Option<(usize, u16)> = None;
+
+        let mut start = 0usize;
+        while start < last_start {
+            // Mask out any over-read lanes and any lanes that can't possibly match the needle
+            let usable = last_start - start;
+            let valid = if usable >= B::LANES {
+                B::Mask::all()
+            } else {
+                B::Mask::first_n(usable)
+            };
+
+            // Seed window lane `k` corresponds to position `pos = start + k`: it reads
+            // `haystack[start + seed_off + k] = haystack[pos + seed_off]`.
+            let (chunk_a, _) = unsafe { load_window::<B>(haystack, start + self.seed_a_off, len) };
+            let hits_a = unsafe { B::occ(chunk_a, self.seed_a) }.and(valid);
+            // Skip the second load entirely when the first seed matches nowhere in this window.
+            if hits_a.is_zero() {
+                start += B::LANES;
+                continue;
+            }
+
+            // A single-byte needle has only one seed (both offsets will be 0), so skip
+            // Branch predictor will predict this perfectly, so there's no performance cost
+            let mut hits = if self.seed_a_off != self.seed_b_off {
+                let (chunk_b, _) =
+                    unsafe { load_window::<B>(haystack, start + self.seed_b_off, len) };
+                hits_a.and(unsafe { B::occ(chunk_b, self.seed_b) })
+            } else {
+                hits_a
+            };
+            while !hits.is_zero() {
+                let pos = start + unsafe { B::first_hit_pos(hits) };
+                hits = hits.clear_through_lowest(hits);
+                // We've verified the seeds but we have to check the rest of the needle matches now
+                if (!UNICODE && needle_len <= 2) || self.matches_at::<UNICODE>(haystack, pos) {
+                    let score = self.score_at::<UNICODE>(haystack, pos);
+                    if best.is_none_or(|(_, best_score)| score > best_score) {
+                        best = Some((pos, score));
+                    }
+                }
+            }
+            start += B::LANES;
+        }
+        best
+    }
+
+    #[inline(always)]
+    fn guard_against_score_overflow(needle_len: usize, scoring: &Scoring) {
+        // Without gaps, a matched character earns at most one of the capitalization or delimiter
+        // bonuses, plus the case bonus, on top of `match_score`.
+        let max_bonus_per_char =
+            scoring.capitalization_bonus.max(scoring.delimiter_bonus) + scoring.matching_case_bonus;
+        scoring.guard_against_score_overflow(needle_len, max_bonus_per_char);
+    }
+}
+
+#[inline(always)]
+fn is_delimiter(byte: u8) -> bool {
+    byte <= 127 && !byte.is_ascii_alphanumeric()
+}

--- a/src/literal/backend.rs
+++ b/src/literal/backend.rs
@@ -159,11 +159,7 @@ mod backend_parity {
                 Matching::Suffix,
                 Matching::Substring,
             ] {
-                let config = Config {
-                    matching,
-                    sort: false,
-                    ..Config::default()
-                };
+                let config = Config::default().matching(matching).sort(false);
                 let expected = unsafe { probe::<LiteralScalar>(needle, haystack, &config) };
 
                 #[cfg(target_arch = "x86_64")]

--- a/src/literal/backend.rs
+++ b/src/literal/backend.rs
@@ -1,0 +1,209 @@
+//! Target-feature-specific instantiations of the literal matcher, mirroring
+//! `src/matcher/backend.rs`. Each backend attaches its `#[target_feature]` to the [`Specialized`]
+//! methods, which forward to the `#[inline(always)]` helpers on [`LiteralImpl`].
+
+use super::algo::LiteralImpl;
+use crate::matcher::algo::Specialized;
+use crate::{Config, Match, MatchIndices};
+
+#[cfg(target_arch = "aarch64")]
+use crate::prefilter::backend::PrefilterNEONBackend;
+use crate::prefilter::backend::PrefilterScalarBackend;
+#[cfg(target_arch = "x86_64")]
+use crate::prefilter::backend::{PrefilterAVX512Backend, PrefilterAVXBackend, PrefilterSSEBackend};
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) type LiteralAVX512 = LiteralImpl<PrefilterAVX512Backend>;
+#[cfg(target_arch = "x86_64")]
+pub(crate) type LiteralAVX = LiteralImpl<PrefilterAVXBackend>;
+#[cfg(target_arch = "x86_64")]
+pub(crate) type LiteralSSE = LiteralImpl<PrefilterSSEBackend>;
+#[cfg(target_arch = "aarch64")]
+pub(crate) type LiteralNEON = LiteralImpl<PrefilterNEONBackend>;
+pub(crate) type LiteralScalar = LiteralImpl<PrefilterScalarBackend>;
+
+/// Implements [`Specialized`] for one literal backend. `TYPOS` is ignored (literal matching has no
+/// typo tolerance); `UNICODE` selects the byte-level ASCII path or the per-codepoint unicode path.
+macro_rules! impl_specialized_literal {
+    ($backend:ty $(, target_feature = $feature:literal)?) => {
+        impl Specialized for LiteralImpl<$backend> {
+            #[inline]
+            $(#[target_feature(enable = $feature)])?
+            unsafe fn build(needle: &str, config: &Config) -> Self {
+                unsafe { Self::new(needle, config) }
+            }
+
+            $(#[target_feature(enable = $feature)])?
+            unsafe fn match_list<const TYPOS: u16, const UNICODE: bool, H: AsRef<str>>(
+                &mut self,
+                haystacks: &[H],
+                haystack_index_offset: u32,
+                matches: &mut Vec<Match>,
+            ) {
+                unsafe {
+                    self.match_list_impl::<UNICODE, H>(haystacks, haystack_index_offset, matches)
+                }
+            }
+
+            $(#[target_feature(enable = $feature)])?
+            unsafe fn match_list_indices<const TYPOS: u16, const UNICODE: bool, H: AsRef<str>>(
+                &mut self,
+                haystacks: &[H],
+            ) -> Vec<MatchIndices> {
+                unsafe { self.match_list_indices_impl::<UNICODE, H>(haystacks) }
+            }
+
+            $(#[target_feature(enable = $feature)])?
+            unsafe fn match_one<const TYPOS: u16, const UNICODE: bool, H: AsRef<str>>(
+                &mut self,
+                haystack: H,
+                index: u32,
+            ) -> Option<Match> {
+                unsafe { self.match_one_impl::<UNICODE, H>(haystack, index) }
+            }
+
+            $(#[target_feature(enable = $feature)])?
+            unsafe fn match_one_indices<const TYPOS: u16, const UNICODE: bool, H: AsRef<str>>(
+                &mut self,
+                haystack: H,
+                index: u32,
+            ) -> Option<MatchIndices> {
+                unsafe { self.match_one_indices_impl::<UNICODE, H>(haystack, index) }
+            }
+        }
+    };
+}
+
+#[cfg(target_arch = "x86_64")]
+impl_specialized_literal!(
+    PrefilterAVX512Backend,
+    target_feature = "avx512f,avx512bw,bmi1,bmi2"
+);
+#[cfg(target_arch = "x86_64")]
+impl_specialized_literal!(PrefilterAVXBackend, target_feature = "avx2");
+#[cfg(target_arch = "x86_64")]
+impl_specialized_literal!(PrefilterSSEBackend, target_feature = "sse2");
+#[cfg(target_arch = "aarch64")]
+impl_specialized_literal!(PrefilterNEONBackend, target_feature = "neon");
+impl_specialized_literal!(PrefilterScalarBackend);
+
+#[cfg(test)]
+mod backend_parity {
+    use crate::matcher::algo::Specialized;
+    use crate::{Config, Matching};
+
+    /// Runs one needle/haystack through a specialized literal backend, returning the observable
+    /// result of both `match_one` and `match_one_indices`. `UNICODE` is chosen the same way the real
+    /// dispatch chooses it (`respects_unicode_for`), so non-ASCII needles exercise the codepoint
+    /// path on every backend.
+    #[allow(clippy::type_complexity)]
+    unsafe fn probe<T: Specialized>(
+        needle: &str,
+        haystack: &str,
+        config: &Config,
+    ) -> (Option<(u16, bool)>, Option<Vec<usize>>) {
+        let mut matcher = unsafe { T::build(needle, config) };
+        let (m, i) = if config.unicode.respects_unicode_for(needle) {
+            (
+                unsafe { matcher.match_one::<0, true, &str>(haystack, 0) },
+                unsafe { matcher.match_one_indices::<0, true, &str>(haystack, 0) },
+            )
+        } else {
+            (
+                unsafe { matcher.match_one::<0, false, &str>(haystack, 0) },
+                unsafe { matcher.match_one_indices::<0, false, &str>(haystack, 0) },
+            )
+        };
+        (m.map(|m| (m.score, m.exact)), i.map(|i| i.indices))
+    }
+
+    #[test]
+    fn simd_backends_agree_with_scalar() {
+        use crate::literal::LiteralScalar;
+
+        let cases: &[(&str, &str)] = &[
+            ("bar", "foobar"),
+            ("bar", "foo_bar"),
+            ("bar", "barbarbar"),
+            ("ab", "ab_ab"),
+            ("foo", "foo"),
+            ("x", &"y".repeat(200)),
+            ("needle", "xxneedlexxneedle_needle"),
+            ("é다😀", "xxé다😀yyé다😀"),
+            ("다", "가나다라마"),
+            ("z", "abcdefghijklmnopqrstuvwxyz"),
+            ("FoO", "prefix_FoO_FOO_foo"),
+            // Two-byte prefilter stress: common first byte, len 1/2, first == last, match at the
+            // end, and overlapping occurrences.
+            ("a", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            ("ab", "abababababababababababab"),
+            ("aa", "baaab"),
+            ("aaaa", "xaaaaaaaax"),
+            ("aaa", "aaaaa"),
+            ("bar", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxbar"),
+            ("ba", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaba"),
+            ("foobar", "foobatefoobarfoobar"),
+            // Unicode codepoint path with case folding: mixed-case occurrences, script mixes, and
+            // the Cherokee hybrid (E1 8E A0 / EA AD B0) that per-byte matching would wrongly accept.
+            ("é", "xÉyéZÉ"),
+            ("café", "un CAFÉ, deux cafés"),
+            ("Ꭰ", "\u{1b70}Ꭰꭰ\u{1b70}"),
+            ("иха", "МУХА_ИХА_иха"),
+            ("αβ", "ΑΒβα_αβ"),
+        ];
+
+        for &(needle, haystack) in cases {
+            for matching in [
+                Matching::Exact,
+                Matching::Prefix,
+                Matching::Suffix,
+                Matching::Substring,
+            ] {
+                let config = Config {
+                    matching,
+                    sort: false,
+                    ..Config::default()
+                };
+                let expected = unsafe { probe::<LiteralScalar>(needle, haystack, &config) };
+
+                #[cfg(target_arch = "x86_64")]
+                {
+                    use crate::literal::{LiteralAVX, LiteralAVX512, LiteralSSE};
+                    if LiteralAVX512::is_available() {
+                        assert_eq!(
+                            unsafe { probe::<LiteralAVX512>(needle, haystack, &config) },
+                            expected,
+                            "AVX-512 mismatch: needle={needle:?} haystack={haystack:?} {matching:?}"
+                        );
+                    }
+                    if LiteralAVX::is_available() {
+                        assert_eq!(
+                            unsafe { probe::<LiteralAVX>(needle, haystack, &config) },
+                            expected,
+                            "AVX2 mismatch: needle={needle:?} haystack={haystack:?} {matching:?}"
+                        );
+                    }
+                    if LiteralSSE::is_available() {
+                        assert_eq!(
+                            unsafe { probe::<LiteralSSE>(needle, haystack, &config) },
+                            expected,
+                            "SSE mismatch: needle={needle:?} haystack={haystack:?} {matching:?}"
+                        );
+                    }
+                }
+
+                #[cfg(target_arch = "aarch64")]
+                {
+                    use crate::literal::LiteralNEON;
+                    if LiteralNEON::is_available() {
+                        assert_eq!(
+                            unsafe { probe::<LiteralNEON>(needle, haystack, &config) },
+                            expected,
+                            "NEON mismatch: needle={needle:?} haystack={haystack:?} {matching:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/literal/mod.rs
+++ b/src/literal/mod.rs
@@ -1,0 +1,361 @@
+//! Literal matching: exact / prefix / suffix / substring
+//!
+//! Unlike the fuzzy [`crate::matcher`], literal matching requires the needle to appear as a
+//! *contiguous* run of characters. The only step that benefits from SIMD is finding *where*
+//! the needle occurs (substring search), which reuses [`crate::prefilter::backend::Backend`].
+//!
+//! All of the implementations ignore the `max_typos` parameter for now.
+
+mod algo;
+mod backend;
+mod rank;
+
+pub(crate) use backend::*;
+
+#[cfg(test)]
+mod tests {
+    use crate::r#const::*;
+    use crate::{CaseMatching, Config, Match, Matching, match_list, match_list_indices};
+
+    const CHAR_SCORE: u16 = MATCH_SCORE + MATCHING_CASE_BONUS;
+
+    fn config(matching: Matching) -> Config {
+        Config {
+            matching,
+            sort: false,
+            ..Config::default()
+        }
+    }
+
+    fn scores(matching: Matching, needle: &str, haystacks: &[&str]) -> Vec<(u32, u16, bool)> {
+        match_list(needle, haystacks, &config(matching))
+            .iter()
+            .map(|m: &Match| (m.index, m.score, m.exact))
+            .collect()
+    }
+
+    /// Score of the best-scoring substring occurrence of `needle` in `haystack`. Panics when the
+    /// needle is absent, since the scoring tests always use a present needle.
+    fn get_score(needle: &str, haystack: &str) -> u16 {
+        get_score_case(needle, haystack, CaseMatching::Ignore).expect("needle should be present")
+    }
+
+    /// Best-scoring substring occurrence under the given casing, or `None` when the needle is absent.
+    fn get_score_case(needle: &str, haystack: &str, casing: CaseMatching) -> Option<u16> {
+        let config = Config {
+            matching: Matching::Substring,
+            casing,
+            sort: false,
+            ..Config::default()
+        };
+        match_list(needle, &[haystack], &config)
+            .first()
+            .map(|m| m.score)
+    }
+
+    #[test]
+    fn exact_matches_whole_haystack_only() {
+        let haystacks = ["foo", "foobar", "xfoo", "FOO"];
+        let got = scores(Matching::Exact, "foo", &haystacks);
+        // "foo" (exact, case match) and "FOO" (exact, case-insensitive) match; nothing else.
+        assert_eq!(got.iter().map(|m| m.0).collect::<Vec<_>>(), vec![0, 3]);
+        assert!(got.iter().all(|m| m.2), "all exact");
+    }
+
+    #[test]
+    fn prefix_and_suffix() {
+        let haystacks = ["foobar", "barfoo", "foo", "xfoobar"];
+        assert_eq!(
+            scores(Matching::Prefix, "foo", &haystacks)
+                .iter()
+                .map(|m| m.0)
+                .collect::<Vec<_>>(),
+            vec![0, 2]
+        );
+        assert_eq!(
+            scores(Matching::Suffix, "foo", &haystacks)
+                .iter()
+                .map(|m| m.0)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn substring_finds_interior_matches() {
+        let haystacks = ["xxbarxx", "bar", "nope", "foo_bar"];
+        assert_eq!(
+            scores(Matching::Substring, "bar", &haystacks)
+                .iter()
+                .map(|m| m.0)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 3]
+        );
+    }
+
+    #[test]
+    fn exact_and_prefix_scores_match_fuzzy() {
+        // For matches anchored at position 0, the literal score equals the fuzzy score.
+        for (needle, haystack) in [
+            ("foo", "foo"),
+            ("foo", "foobar"),
+            ("fooBar", "fooBarBaz"),
+            ("a", "abc"),
+        ] {
+            let fuzzy = match_list(needle, &[haystack], &Config::default())[0].score;
+            let prefix = match_list(needle, &[haystack], &config(Matching::Prefix))[0].score;
+            assert_eq!(
+                prefix, fuzzy,
+                "prefix vs fuzzy mismatch for {needle:?} on {haystack:?}"
+            );
+        }
+
+        let fuzzy = match_list("foo", &["foo"], &Config::default())[0].score;
+        let exact = match_list("foo", &["foo"], &config(Matching::Exact))[0].score;
+        assert_eq!(exact, fuzzy);
+    }
+
+    #[test]
+    fn test_score_multibyte_needle() {
+        // Interior "bar" in "foobar": three matched bytes, no prefix or delimiter.
+        assert_eq!(get_score("bar", "foobar"), 3 * CHAR_SCORE);
+        // "bar" after a delimiter earns the delimiter bonus on its first byte.
+        assert_eq!(
+            get_score("bar", "foo_bar"),
+            3 * CHAR_SCORE + DELIMITER_BONUS
+        );
+    }
+
+    #[test]
+    fn substring_picks_best_scoring_occurrence() {
+        // In "ab_ab" the position-0 occurrence (prefix bonus) must beat the one after '_'
+        // (delimiter bonus).
+        assert_eq!(get_score("ab", "ab_ab"), 2 * CHAR_SCORE + PREFIX_BONUS);
+    }
+
+    #[test]
+    fn casing_respect_and_smart() {
+        let haystacks = ["foo", "FOO", "fOo"];
+        // Respect: only exact case.
+        let respect = Config {
+            matching: Matching::Prefix,
+            casing: CaseMatching::Respect,
+            sort: false,
+            ..Config::default()
+        };
+        assert_eq!(
+            match_list("foo", &haystacks, &respect)
+                .iter()
+                .map(|m| m.index)
+                .collect::<Vec<_>>(),
+            vec![0]
+        );
+        // Smart: lowercase needle => case-insensitive.
+        assert_eq!(
+            scores(Matching::Prefix, "foo", &haystacks)
+                .iter()
+                .map(|m| m.0)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[test]
+    fn unicode_substring_and_exact() {
+        let haystacks = ["é다😀", "xxé다😀yy", "é다", "plain"];
+        assert_eq!(
+            scores(Matching::Substring, "é다😀", &haystacks)
+                .iter()
+                .map(|m| m.0)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+        let exact = scores(Matching::Exact, "é다😀", &haystacks);
+        assert_eq!(exact.iter().map(|m| m.0).collect::<Vec<_>>(), vec![0]);
+        assert!(exact[0].2);
+    }
+
+    #[test]
+    fn indices_are_contiguous_reversed() {
+        let matches = match_list_indices("abc", &["xxabcxx"], &config(Matching::Substring));
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].indices, vec![4, 3, 2]);
+    }
+
+    #[test]
+    fn no_match_when_needle_longer_than_haystack() {
+        assert!(scores(Matching::Substring, "abcd", &["abc"]).is_empty());
+        assert!(scores(Matching::Prefix, "abcd", &["abc"]).is_empty());
+        assert!(scores(Matching::Suffix, "abcd", &["abc"]).is_empty());
+        assert!(scores(Matching::Exact, "abcd", &["abc"]).is_empty());
+    }
+
+    #[test]
+    fn substring_scan_handles_chunk_boundaries() {
+        // Exercise occurrences straddling the SIMD lane boundaries of every backend.
+        for prefix_len in [0usize, 1, 7, 8, 15, 16, 31, 32, 63, 64, 65] {
+            let haystack = format!("{}bar", "x".repeat(prefix_len));
+            let got = scores(Matching::Substring, "bar", &[&haystack]);
+            assert_eq!(got.len(), 1, "prefix_len={prefix_len}");
+            assert_eq!(got[0].0, 0);
+        }
+    }
+
+    // The tests below mirror the Smith-Waterman scoring suite (`src/smith_waterman/mod.rs`),
+    // adapted to literal matching: matches are contiguous (so the gap/affine/typo cases do not
+    // apply) and the exact-match bonus is included when the run spans the whole haystack.
+
+    #[test]
+    fn test_score_basic() {
+        assert_eq!(get_score("b", "abc"), CHAR_SCORE);
+        assert_eq!(get_score("c", "abc"), CHAR_SCORE);
+    }
+
+    #[test]
+    fn test_score_prefix() {
+        assert_eq!(get_score("a", "abc"), CHAR_SCORE + PREFIX_BONUS);
+        assert_eq!(get_score("a", "aabc"), CHAR_SCORE + PREFIX_BONUS);
+        assert_eq!(get_score("a", "babc"), CHAR_SCORE);
+    }
+
+    #[test]
+    fn test_score_exact_match() {
+        // Unlike the raw Smith-Waterman scorer, the literal scorer adds the exact-match bonus when
+        // the run covers the whole haystack.
+        assert_eq!(
+            get_score("a", "a"),
+            CHAR_SCORE + PREFIX_BONUS + EXACT_MATCH_BONUS
+        );
+        assert_eq!(
+            get_score("abc", "abc"),
+            3 * CHAR_SCORE + PREFIX_BONUS + EXACT_MATCH_BONUS
+        );
+    }
+
+    #[test]
+    fn test_score_delimiter() {
+        assert_eq!(get_score("-", "a--bc"), CHAR_SCORE);
+        assert_eq!(get_score("b", "a-b"), CHAR_SCORE + DELIMITER_BONUS);
+        assert_eq!(get_score("a", "a-b-c"), CHAR_SCORE + PREFIX_BONUS);
+        assert_eq!(get_score("b", "a--b"), CHAR_SCORE + DELIMITER_BONUS);
+        assert_eq!(get_score("c", "a--bc"), CHAR_SCORE);
+        assert_eq!(get_score("a", "-a--bc"), CHAR_SCORE + DELIMITER_BONUS);
+    }
+
+    #[test]
+    fn test_score_no_delimiter_for_delimiter_chars() {
+        assert_eq!(get_score("-", "a-bc"), CHAR_SCORE);
+        assert_eq!(get_score("-", "a--bc"), CHAR_SCORE);
+    }
+
+    #[test]
+    fn test_score_capital_bonus() {
+        assert_eq!(get_score("a", "Ab"), MATCH_SCORE + PREFIX_BONUS);
+        assert_eq!(get_score("A", "Aa"), CHAR_SCORE + PREFIX_BONUS);
+        assert_eq!(get_score("D", "forDist"), CHAR_SCORE + CAPITALIZATION_BONUS);
+        assert_eq!(get_score("D", "foRDist"), CHAR_SCORE);
+        assert_eq!(get_score("D", "FOR_DIST"), CHAR_SCORE + DELIMITER_BONUS);
+    }
+
+    #[test]
+    fn test_score_prefix_beats_delimiter() {
+        assert!(get_score("swap", "swap(test)") > get_score("swap", "iter_swap(test)"));
+        assert!(get_score("_", "_private_member") > get_score("_", "public_member"));
+    }
+
+    #[test]
+    fn test_score_prefix_beats_capitalization() {
+        assert!(get_score("H", "HELLO") > get_score("H", "fooHello"));
+    }
+
+    #[test]
+    fn bonus_precedence_manual_cases() {
+        assert!(get_score("b", "b") > get_score("b", "a-b"));
+        assert!(get_score("b", "a-b") > get_score("b", "ab"));
+        assert!(get_score("B", "aB") > get_score("b", "aB"));
+    }
+
+    #[test]
+    fn case_sensitive_scoring_rejects_folded_bytes() {
+        // A digit prefix keeps the seed byte free of capitalization/delimiter bonuses.
+        assert_eq!(
+            get_score_case("A", "0A", CaseMatching::Respect),
+            Some(CHAR_SCORE)
+        );
+        assert_eq!(get_score_case("A", "0a", CaseMatching::Respect), None);
+        assert_eq!(
+            get_score_case("A", "0a", CaseMatching::Ignore),
+            Some(MATCH_SCORE)
+        );
+    }
+
+    // Unicode matching: a non-ASCII needle takes the per-codepoint path. Multibyte characters are
+    // scored once (not once per UTF-8 byte) and case folding compares whole codepoints.
+
+    #[test]
+    fn test_score_unicode_per_codepoint() {
+        // "é" is two UTF-8 bytes but scores as a single matched character.
+        assert_eq!(
+            get_score("é", "é"),
+            CHAR_SCORE + PREFIX_BONUS + EXACT_MATCH_BONUS
+        );
+        // Two codepoints (é is 2 bytes, x is 1) score as two characters, not three bytes.
+        assert_eq!(
+            get_score("éx", "éx"),
+            2 * CHAR_SCORE + PREFIX_BONUS + EXACT_MATCH_BONUS
+        );
+        // An interior occurrence: only "é" is scored, the leading "x" is not.
+        assert_eq!(get_score("é", "xé"), CHAR_SCORE);
+    }
+
+    #[test]
+    fn unicode_case_insensitive_fold() {
+        // Whole-codepoint case folding across several scripts (é/É, Cyrillic и/И, Greek α/Α).
+        for (needle, upper) in [("é", "É"), ("и", "И"), ("α", "Α")] {
+            assert!(
+                get_score_case(needle, upper, CaseMatching::Ignore).is_some(),
+                "{needle:?} should fold to {upper:?}"
+            );
+            assert_eq!(
+                get_score_case(needle, upper, CaseMatching::Respect),
+                None,
+                "{needle:?} must not match {upper:?} when respecting case"
+            );
+        }
+    }
+
+    #[test]
+    fn unicode_rejects_hybrid_case_bytes() {
+        // Cherokee case pairs are the same length but differ in every byte:
+        //   'Ꭰ' U+13A0 = E1 8E A0, 'ꭰ' U+AB70 = EA AD B0.
+        // A per-byte verifier would accept the hybrid E1 AD B0 (= U+1B70 '᭰'); the codepoint
+        // verifier must reject it while still matching the true lowercase form.
+        assert_eq!(
+            get_score_case("Ꭰ", "\u{1b70}", CaseMatching::Ignore),
+            None,
+            "hybrid byte sequence must not match"
+        );
+        assert!(
+            get_score_case("Ꭰ", "ꭰ", CaseMatching::Ignore).is_some(),
+            "true lowercase form must match"
+        );
+    }
+
+    #[test]
+    fn unicode_length_changing_fold_is_case_sensitive() {
+        // 'ß' folds to "SS" (a length change), so it is treated case-sensitively: it matches only
+        // itself, never "SS"/"ss".
+        assert!(get_score_case("ß", "ß", CaseMatching::Ignore).is_some());
+        assert_eq!(get_score_case("ß", "SS", CaseMatching::Ignore), None);
+        assert_eq!(get_score_case("ß", "ss", CaseMatching::Ignore), None);
+    }
+
+    #[test]
+    fn unicode_indices_span_whole_utf8_run() {
+        // Matched indices are byte offsets covering the full UTF-8 run, reversed.
+        let matches = match_list_indices("é다", &["xxé다yy"], &config(Matching::Substring));
+        assert_eq!(matches.len(), 1);
+        // "xx" is two bytes; "é" occupies bytes 2..4, "다" bytes 4..7.
+        assert_eq!(matches[0].indices, vec![6, 5, 4, 3, 2]);
+    }
+}

--- a/src/literal/mod.rs
+++ b/src/literal/mod.rs
@@ -20,11 +20,7 @@ mod tests {
     const CHAR_SCORE: u16 = MATCH_SCORE + MATCHING_CASE_BONUS;
 
     fn config(matching: Matching) -> Config {
-        Config {
-            matching,
-            sort: false,
-            ..Config::default()
-        }
+        Config::default().matching(matching).sort(false)
     }
 
     fn scores(matching: Matching, needle: &str, haystacks: &[&str]) -> Vec<(u32, u16, bool)> {
@@ -42,12 +38,10 @@ mod tests {
 
     /// Best-scoring substring occurrence under the given casing, or `None` when the needle is absent.
     fn get_score_case(needle: &str, haystack: &str, casing: CaseMatching) -> Option<u16> {
-        let config = Config {
-            matching: Matching::Substring,
-            casing,
-            sort: false,
-            ..Config::default()
-        };
+        let config = Config::default()
+            .matching(Matching::Substring)
+            .casing(casing)
+            .sort(false);
         match_list(needle, &[haystack], &config)
             .first()
             .map(|m| m.score)
@@ -137,12 +131,10 @@ mod tests {
     fn casing_respect_and_smart() {
         let haystacks = ["foo", "FOO", "fOo"];
         // Respect: only exact case.
-        let respect = Config {
-            matching: Matching::Prefix,
-            casing: CaseMatching::Respect,
-            sort: false,
-            ..Config::default()
-        };
+        let respect = Config::default()
+            .matching(Matching::Prefix)
+            .casing(CaseMatching::Respect)
+            .sort(false);
         assert_eq!(
             match_list("foo", &haystacks, &respect)
                 .iter()

--- a/src/literal/rank.rs
+++ b/src/literal/rank.rs
@@ -1,0 +1,335 @@
+//! Rates the likelihood of a byte appearing in a haystack
+//! Source: https://github.com/BurntSushi/memchr/blob/master/src/arch/all/packedpair/default_rank.rs
+//! MIT License
+//! Copyright (c) 2015 Andrew Gallant
+
+pub(super) const RANK: [u8; 256] = [
+    55,  // '\x00'
+    52,  // '\x01'
+    51,  // '\x02'
+    50,  // '\x03'
+    49,  // '\x04'
+    48,  // '\x05'
+    47,  // '\x06'
+    46,  // '\x07'
+    45,  // '\x08'
+    103, // '\t'
+    242, // '\n'
+    66,  // '\x0b'
+    67,  // '\x0c'
+    229, // '\r'
+    44,  // '\x0e'
+    43,  // '\x0f'
+    42,  // '\x10'
+    41,  // '\x11'
+    40,  // '\x12'
+    39,  // '\x13'
+    38,  // '\x14'
+    37,  // '\x15'
+    36,  // '\x16'
+    35,  // '\x17'
+    34,  // '\x18'
+    33,  // '\x19'
+    56,  // '\x1a'
+    32,  // '\x1b'
+    31,  // '\x1c'
+    30,  // '\x1d'
+    29,  // '\x1e'
+    28,  // '\x1f'
+    255, // ' '
+    148, // '!'
+    164, // '"'
+    149, // '#'
+    136, // '$'
+    160, // '%'
+    155, // '&'
+    173, // "'"
+    221, // '('
+    222, // ')'
+    134, // '*'
+    122, // '+'
+    232, // ','
+    202, // '-'
+    215, // '.'
+    224, // '/'
+    208, // '0'
+    220, // '1'
+    204, // '2'
+    187, // '3'
+    183, // '4'
+    179, // '5'
+    177, // '6'
+    168, // '7'
+    178, // '8'
+    200, // '9'
+    226, // ':'
+    195, // ';'
+    154, // '<'
+    184, // '='
+    174, // '>'
+    126, // '?'
+    120, // '@'
+    191, // 'A'
+    157, // 'B'
+    194, // 'C'
+    170, // 'D'
+    189, // 'E'
+    162, // 'F'
+    161, // 'G'
+    150, // 'H'
+    193, // 'I'
+    142, // 'J'
+    137, // 'K'
+    171, // 'L'
+    176, // 'M'
+    185, // 'N'
+    167, // 'O'
+    186, // 'P'
+    112, // 'Q'
+    175, // 'R'
+    192, // 'S'
+    188, // 'T'
+    156, // 'U'
+    140, // 'V'
+    143, // 'W'
+    123, // 'X'
+    133, // 'Y'
+    128, // 'Z'
+    147, // '['
+    138, // '\\'
+    146, // ']'
+    114, // '^'
+    223, // '_'
+    151, // '`'
+    249, // 'a'
+    216, // 'b'
+    238, // 'c'
+    236, // 'd'
+    253, // 'e'
+    227, // 'f'
+    218, // 'g'
+    230, // 'h'
+    247, // 'i'
+    135, // 'j'
+    180, // 'k'
+    241, // 'l'
+    233, // 'm'
+    246, // 'n'
+    244, // 'o'
+    231, // 'p'
+    139, // 'q'
+    245, // 'r'
+    243, // 's'
+    251, // 't'
+    235, // 'u'
+    201, // 'v'
+    196, // 'w'
+    240, // 'x'
+    214, // 'y'
+    152, // 'z'
+    182, // '{'
+    205, // '|'
+    181, // '}'
+    127, // '~'
+    27,  // '\x7f'
+    212, // '\x80'
+    211, // '\x81'
+    210, // '\x82'
+    213, // '\x83'
+    228, // '\x84'
+    197, // '\x85'
+    169, // '\x86'
+    159, // '\x87'
+    131, // '\x88'
+    172, // '\x89'
+    105, // '\x8a'
+    80,  // '\x8b'
+    98,  // '\x8c'
+    96,  // '\x8d'
+    97,  // '\x8e'
+    81,  // '\x8f'
+    207, // '\x90'
+    145, // '\x91'
+    116, // '\x92'
+    115, // '\x93'
+    144, // '\x94'
+    130, // '\x95'
+    153, // '\x96'
+    121, // '\x97'
+    107, // '\x98'
+    132, // '\x99'
+    109, // '\x9a'
+    110, // '\x9b'
+    124, // '\x9c'
+    111, // '\x9d'
+    82,  // '\x9e'
+    108, // '\x9f'
+    118, // '\xa0'
+    141, // '¡'
+    113, // '¢'
+    129, // '£'
+    119, // '¤'
+    125, // '¥'
+    165, // '¦'
+    117, // '§'
+    92,  // '¨'
+    106, // '©'
+    83,  // 'ª'
+    72,  // '«'
+    99,  // '¬'
+    93,  // '\xad'
+    65,  // '®'
+    79,  // '¯'
+    166, // '°'
+    237, // '±'
+    163, // '²'
+    199, // '³'
+    190, // '´'
+    225, // 'µ'
+    209, // '¶'
+    203, // '·'
+    198, // '¸'
+    217, // '¹'
+    219, // 'º'
+    206, // '»'
+    234, // '¼'
+    248, // '½'
+    158, // '¾'
+    239, // '¿'
+    255, // 'À'
+    255, // 'Á'
+    255, // 'Â'
+    255, // 'Ã'
+    255, // 'Ä'
+    255, // 'Å'
+    255, // 'Æ'
+    255, // 'Ç'
+    255, // 'È'
+    255, // 'É'
+    255, // 'Ê'
+    255, // 'Ë'
+    255, // 'Ì'
+    255, // 'Í'
+    255, // 'Î'
+    255, // 'Ï'
+    255, // 'Ð'
+    255, // 'Ñ'
+    255, // 'Ò'
+    255, // 'Ó'
+    255, // 'Ô'
+    255, // 'Õ'
+    255, // 'Ö'
+    255, // '×'
+    255, // 'Ø'
+    255, // 'Ù'
+    255, // 'Ú'
+    255, // 'Û'
+    255, // 'Ü'
+    255, // 'Ý'
+    255, // 'Þ'
+    255, // 'ß'
+    255, // 'à'
+    255, // 'á'
+    255, // 'â'
+    255, // 'ã'
+    255, // 'ä'
+    255, // 'å'
+    255, // 'æ'
+    255, // 'ç'
+    255, // 'è'
+    255, // 'é'
+    255, // 'ê'
+    255, // 'ë'
+    255, // 'ì'
+    255, // 'í'
+    255, // 'î'
+    255, // 'ï'
+    255, // 'ð'
+    255, // 'ñ'
+    255, // 'ò'
+    255, // 'ó'
+    255, // 'ô'
+    255, // 'õ'
+    255, // 'ö'
+    255, // '÷'
+    255, // 'ø'
+    255, // 'ù'
+    255, // 'ú'
+    255, // 'û'
+    255, // 'ü'
+    255, // 'ý'
+    255, // 'þ'
+    255, // 'ÿ'
+];
+
+/// Picks the byte offsets of the two rarest bytes in `needle` (lowest [`RANK`], i.e. least likely to
+/// appear in a haystack), returning them ordered as `(lower, higher)`. The two offsets always differ
+/// and, when possible, point at two distinct byte values, maximizing the selectivity of the
+/// two-byte substring prefilter. Mirrors the heuristic in memchr's `packedpair`.
+///
+/// Requires `needle.len() >= 2`.
+pub(super) fn rare_byte_offsets(needle: &[u8]) -> (usize, usize) {
+    debug_assert!(
+        needle.len() >= 2,
+        "rare_byte_offsets requires at least two bytes"
+    );
+
+    let rank = |byte: u8| RANK[byte as usize];
+
+    // Seed the search with the first two bytes, keeping the rarer of the two as `rare1`.
+    let (mut rare1, mut offset1) = (needle[0], 0usize);
+    let (mut rare2, mut offset2) = (needle[1], 1usize);
+    if rank(rare2) < rank(rare1) {
+        std::mem::swap(&mut rare1, &mut rare2);
+        std::mem::swap(&mut offset1, &mut offset2);
+    }
+
+    for (offset, &byte) in needle.iter().enumerate().skip(2) {
+        if rank(byte) < rank(rare1) {
+            // A new rarest byte; the previous rarest becomes the runner-up.
+            rare2 = rare1;
+            offset2 = offset1;
+            rare1 = byte;
+            offset1 = offset;
+        } else if byte != rare1 && rank(byte) < rank(rare2) {
+            rare2 = byte;
+            offset2 = offset;
+        }
+    }
+
+    if offset1 <= offset2 {
+        (offset1, offset2)
+    } else {
+        (offset2, offset1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RANK, rare_byte_offsets};
+
+    #[test]
+    fn returns_two_distinct_ordered_offsets() {
+        let (a, b) = rare_byte_offsets(b"abcd");
+        assert!(
+            a < b && b < 4,
+            "expected ordered distinct offsets, got ({a}, {b})"
+        );
+    }
+
+    #[test]
+    fn prefers_rarer_bytes_over_position() {
+        // 'z' is far rarer than 'a', so it must be chosen even though it is neither first nor last.
+        assert!(RANK[b'z' as usize] < RANK[b'a' as usize]);
+        let (a, b) = rare_byte_offsets(b"aazaa");
+        assert!(
+            a == 2 || b == 2,
+            "expected the 'z' at offset 2 to be a seed, got ({a}, {b})"
+        );
+    }
+
+    #[test]
+    fn all_identical_bytes_fall_back_to_adjacent_offsets() {
+        assert_eq!(rare_byte_offsets(b"aaaa"), (0, 1));
+    }
+}

--- a/src/matcher/algo.rs
+++ b/src/matcher/algo.rs
@@ -332,10 +332,7 @@ mod tests {
     #[test]
     fn unsorted_output_preserves_candidate_order() {
         let haystacks = ["foo", "nomatch", "xfoo", "f_o_o", "bar"];
-        let config = Config {
-            sort: false,
-            ..Config::default()
-        };
+        let config = Config::default().sort(false);
 
         let matches = match_list("foo", &haystacks, &config);
         assert_eq!(
@@ -350,10 +347,7 @@ mod tests {
     #[test]
     fn match_list_indices_reports_expected_public_indices() {
         let haystacks = ["xabcx", "a_b_c", "nomatch"];
-        let config = Config {
-            sort: false,
-            ..Config::default()
-        };
+        let config = Config::default().sort(false);
 
         let matches = match_list_indices("abc", &haystacks, &config);
         assert_eq!(matches.len(), 2);
@@ -366,10 +360,7 @@ mod tests {
     #[test]
     #[cfg(feature = "match_end_col")]
     fn filtered_match_end_col_uses_original_haystack_offsets() {
-        let config = Config {
-            sort: false,
-            ..Config::default()
-        };
+        let config = Config::default().sort(false);
 
         let matches = match_list("abc", &["xxabcxx"], &config);
         assert_eq!(matches.len(), 1);

--- a/src/matcher/algo.rs
+++ b/src/matcher/algo.rs
@@ -313,21 +313,15 @@ where
 
     #[inline(always)]
     fn guard_against_score_overflow(&self) {
+        // The largest bonus a matched character can earn on top of `match_score`: a gap-adjusted
+        // delimiter or half a capitalization bonus (whichever is larger), plus the case bonus.
         let scoring = &self.config.scoring;
-        let max_per_char_score = scoring.match_score
-            + scoring
-                .delimiter_bonus
-                .saturating_sub(scoring.gap_open_penalty)
-                .max(scoring.capitalization_bonus.div_ceil(2))
+        let max_bonus_per_char = scoring
+            .delimiter_bonus
+            .saturating_sub(scoring.gap_open_penalty)
+            .max(scoring.capitalization_bonus.div_ceil(2))
             + scoring.matching_case_bonus;
-        let max_needle_len =
-            (u16::MAX - scoring.prefix_bonus - scoring.exact_match_bonus) / max_per_char_score;
-        assert!(
-            self.needle.len() <= max_needle_len as usize,
-            "needle too long and could overflow the u16 score: {} > {}",
-            self.needle.len(),
-            max_needle_len
-        );
+        scoring.guard_against_score_overflow(self.needle.len(), max_bonus_per_char);
     }
 }
 

--- a/src/matcher/backend.rs
+++ b/src/matcher/backend.rs
@@ -4,6 +4,12 @@ use super::algo::{MatcherImpl, Specialized};
 use crate::{Config, Match, MatchIndices};
 
 #[cfg(target_arch = "aarch64")]
+use crate::literal::LiteralNEON;
+use crate::literal::LiteralScalar;
+#[cfg(target_arch = "x86_64")]
+use crate::literal::{LiteralAVX, LiteralAVX512, LiteralSSE};
+
+#[cfg(target_arch = "aarch64")]
 use crate::prefilter::backend::PrefilterNEON;
 use crate::prefilter::backend::PrefilterScalar;
 #[cfg(target_arch = "x86_64")]
@@ -58,6 +64,18 @@ pub enum MatcherBackend {
     NEON(MatcherNEON),
     ScalarU8(MatcherScalarU8),
     Scalar(MatcherScalar),
+
+    // Literal matching backends (exact / prefix / suffix / substring). Selected when
+    // `Config::matching` is not `Matching::Fuzzy`.
+    #[cfg(target_arch = "x86_64")]
+    LiteralAVX512(LiteralAVX512),
+    #[cfg(target_arch = "x86_64")]
+    LiteralAVX(LiteralAVX),
+    #[cfg(target_arch = "x86_64")]
+    LiteralSSE(LiteralSSE),
+    #[cfg(target_arch = "aarch64")]
+    LiteralNEON(LiteralNEON),
+    LiteralScalar(LiteralScalar),
 }
 
 /// Implements [`Specialized`] for one concrete backend, attaching the

--- a/src/matcher/iter.rs
+++ b/src/matcher/iter.rs
@@ -154,11 +154,7 @@ mod tests {
     fn fuzzy_match_matches_match_iter() {
         for needle in ["deadbe", "é다😀"] {
             for max_typos in [None, Some(0), Some(1), Some(2), Some(3)] {
-                let config = Config {
-                    max_typos,
-                    sort: false,
-                    ..Config::default()
-                };
+                let config = Config::default().max_typos(max_typos).sort(false);
                 let from_ext = HAYSTACKS
                     .iter()
                     .fuzzy_match(needle, &config)
@@ -178,11 +174,7 @@ mod tests {
     fn fuzzy_match_indices_matches_match_iter_indices() {
         for needle in ["deadbe", "é다😀"] {
             for max_typos in [None, Some(0), Some(1), Some(2), Some(3)] {
-                let config = Config {
-                    max_typos,
-                    sort: false,
-                    ..Config::default()
-                };
+                let config = Config::default().max_typos(max_typos).sort(false);
                 let from_ext = HAYSTACKS
                     .iter()
                     .fuzzy_match_indices(needle, &config)
@@ -226,14 +218,7 @@ mod tests {
         let scores = HAYSTACKS
             .iter()
             .filter(|h| !h.starts_with("no"))
-            .fuzzy_match(
-                "deadbe",
-                &Config {
-                    max_typos: Some(0),
-                    sort: false,
-                    ..Config::default()
-                },
-            )
+            .fuzzy_match("deadbe", &Config::default().max_typos(Some(0)).sort(false))
             .map(|m| m.index)
             .collect::<Vec<_>>();
         assert!(!scores.is_empty());

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -392,10 +392,7 @@ mod tests {
         let needle = "deadbe";
         let haystack = vec!["deadbeef", "deadbf", "deadbeefg", "deadbe"];
 
-        let config = Config {
-            max_typos: None,
-            ..Config::default()
-        };
+        let config = Config::default().max_typos(None);
         let matches = match_list(needle, &haystack, &config);
 
         println!("{:?}", matches);
@@ -411,14 +408,7 @@ mod tests {
         let needle = "deadbe";
         let haystack = vec!["deadbeef", "deadbf", "deadbeefg", "deadbe"];
 
-        let matches = match_list(
-            needle,
-            &haystack,
-            &Config {
-                max_typos: Some(0),
-                ..Config::default()
-            },
-        );
+        let matches = match_list(needle, &haystack, &Config::default().max_typos(Some(0)));
         assert_eq!(matches.len(), 3);
     }
 
@@ -461,10 +451,7 @@ mod tests {
 
     #[test]
     fn test_small_needle() {
-        let config = Config {
-            max_typos: Some(2),
-            ..Config::default()
-        };
+        let config = Config::default().max_typos(Some(2));
         let matches = match_list("1", &["1"], &config);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].index, 0);
@@ -474,10 +461,7 @@ mod tests {
     #[test]
     fn test_case_sensitive_matching() {
         let haystack = ["foo", "FOO", "fOo", "xxfooxx"];
-        let config = Config {
-            sort: false,
-            ..Config::default()
-        };
+        let config = Config::default().sort(false);
 
         let matches = match_list("foo", &haystack, &config);
         assert_eq!(
@@ -485,11 +469,7 @@ mod tests {
             vec![0, 1, 2, 3]
         );
 
-        let config = Config {
-            casing: CaseMatching::Respect,
-            sort: false,
-            ..Config::default()
-        };
+        let config = Config::default().casing(CaseMatching::Respect).sort(false);
 
         let matches = match_list("foo", &haystack, &config);
         assert_eq!(
@@ -503,11 +483,7 @@ mod tests {
             vec![0, 3]
         );
 
-        let config = Config {
-            casing: CaseMatching::Smart,
-            sort: false,
-            ..Config::default()
-        };
+        let config = Config::default().casing(CaseMatching::Smart).sort(false);
 
         let matches = match_list("FoO", &["foo", "FOO", "FoO", "xxFoOxx"], &config);
         assert_eq!(
@@ -529,11 +505,7 @@ mod tests {
         ];
         for needle in ["deadbe", "é다😀"] {
             for max_typos in [None, Some(0), Some(1), Some(2), Some(3)] {
-                let config = Config {
-                    max_typos,
-                    sort: false,
-                    ..Config::default()
-                };
+                let config = Config::default().max_typos(max_typos).sort(false);
                 let mut matcher = Matcher::new(needle, &config);
                 let from_iter = matcher.match_iter(haystacks.iter()).collect::<Vec<_>>();
                 let from_list = matcher.match_list(&haystacks);
@@ -569,11 +541,7 @@ mod tests {
         ];
         for needle in ["deadbe", "é다😀"] {
             for max_typos in [None, Some(0), Some(1), Some(2), Some(3)] {
-                let config = Config {
-                    max_typos,
-                    sort: false,
-                    ..Config::default()
-                };
+                let config = Config::default().max_typos(max_typos).sort(false);
                 let mut matcher = Matcher::new(needle, &config);
                 let from_iter = matcher
                     .match_iter_indices(haystacks.iter())
@@ -663,11 +631,7 @@ mod tests {
             "abcdefghijklmnopqrst".to_string(),
             "no-match".to_string(),
         ];
-        let first_config = Config {
-            max_typos: None,
-            sort: false,
-            ..Config::default()
-        };
+        let first_config = Config::default().max_typos(None).sort(false);
         let mut matcher = Matcher::new(long_needle, &first_config);
 
         let first = matcher.match_list(&first_haystacks);
@@ -683,11 +647,7 @@ mod tests {
             "bar".to_string(),
         ];
         matcher.set_needle("fB");
-        let second_config = Config {
-            casing: CaseMatching::Smart,
-            sort: false,
-            ..Config::default()
-        };
+        let second_config = Config::default().casing(CaseMatching::Smart).sort(false);
         matcher.set_config(second_config.clone());
         let second = matcher.match_list(&second_haystacks);
         assert_eq!(
@@ -702,11 +662,7 @@ mod tests {
             "plain ascii".to_string(),
         ];
         matcher.set_needle("é다😀");
-        let unicode_config = Config {
-            max_typos: Some(0),
-            sort: false,
-            ..Config::default()
-        };
+        let unicode_config = Config::default().max_typos(Some(0)).sort(false);
         matcher.set_config(unicode_config.clone());
         let unicode = matcher.match_list(&unicode_haystacks);
         assert_eq!(
@@ -715,12 +671,10 @@ mod tests {
         );
 
         matcher.set_needle("fB");
-        let third_config = Config {
-            casing: CaseMatching::Ignore,
-            max_typos: Some(1),
-            sort: true,
-            ..Config::default()
-        };
+        let third_config = Config::default()
+            .casing(CaseMatching::Ignore)
+            .max_typos(Some(1))
+            .sort(true);
         matcher.set_config(third_config.clone());
         let third = matcher.match_list(&first_haystacks);
         assert_eq!(&third, &match_list("fB", &first_haystacks, &third_config));
@@ -729,11 +683,7 @@ mod tests {
     #[test]
     #[cfg(feature = "match_end_col")]
     fn test_match_end_col_through_match_list() {
-        let config = Config {
-            max_typos: None,
-            sort: false,
-            ..Config::default()
-        };
+        let config = Config::default().max_typos(None).sort(false);
         let matches = match_list("abc", &["xabcx", "abcdef", "xxabc"], &config);
         assert_eq!(matches.len(), 3);
         assert_eq!(matches[0].end_col, 3);

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -2,7 +2,13 @@ use crate::smith_waterman::score_fits_in_u8;
 use crate::sort::radix_sort_matches;
 use crate::{Config, Match, MatchIndices};
 
-mod algo;
+#[cfg(target_arch = "aarch64")]
+use crate::literal::LiteralNEON;
+use crate::literal::LiteralScalar;
+#[cfg(target_arch = "x86_64")]
+use crate::literal::{LiteralAVX, LiteralAVX512, LiteralSSE};
+
+pub(crate) mod algo;
 mod backend;
 mod iter;
 mod parallel;
@@ -10,6 +16,7 @@ use algo::{MANY_TYPOS, NO_PREFILTER, Specialized};
 use backend::*;
 pub use iter::{FuzzyMatch, FuzzyMatchExt, FuzzyMatchIndices};
 
+/// Primary entrypoint for fuzzy matching
 #[derive(Debug, Clone)]
 pub struct Matcher {
     needle: String,
@@ -40,6 +47,15 @@ macro_rules! dispatch {
             MatcherBackend::NEON($m) => $body,
             MatcherBackend::ScalarU8($m) => $body,
             MatcherBackend::Scalar($m) => $body,
+            #[cfg(target_arch = "x86_64")]
+            MatcherBackend::LiteralAVX512($m) => $body,
+            #[cfg(target_arch = "x86_64")]
+            MatcherBackend::LiteralAVX($m) => $body,
+            #[cfg(target_arch = "x86_64")]
+            MatcherBackend::LiteralSSE($m) => $body,
+            #[cfg(target_arch = "aarch64")]
+            MatcherBackend::LiteralNEON($m) => $body,
+            MatcherBackend::LiteralScalar($m) => $body,
         }
     };
 }
@@ -288,6 +304,10 @@ impl Matcher {
     }
 
     fn get_backend(needle: &str, config: &Config) -> MatcherBackend {
+        if !config.matching.is_fuzzy() {
+            return Self::get_literal_backend(needle, config);
+        }
+
         let use_u8 = score_fits_in_u8(needle.len(), &config.scoring);
 
         #[cfg(target_arch = "x86_64")]
@@ -333,6 +353,32 @@ impl Matcher {
         } else {
             MatcherBackend::Scalar(unsafe { MatcherScalar::build(needle, config) })
         }
+    }
+
+    fn get_literal_backend(needle: &str, config: &Config) -> MatcherBackend {
+        #[cfg(target_arch = "x86_64")]
+        {
+            if LiteralAVX512::is_available() {
+                return MatcherBackend::LiteralAVX512(unsafe {
+                    LiteralAVX512::build(needle, config)
+                });
+            }
+            if LiteralAVX::is_available() {
+                return MatcherBackend::LiteralAVX(unsafe { LiteralAVX::build(needle, config) });
+            }
+            if LiteralSSE::is_available() {
+                return MatcherBackend::LiteralSSE(unsafe { LiteralSSE::build(needle, config) });
+            }
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            if LiteralNEON::is_available() {
+                return MatcherBackend::LiteralNEON(unsafe { LiteralNEON::build(needle, config) });
+            }
+        }
+
+        MatcherBackend::LiteralScalar(unsafe { LiteralScalar::build(needle, config) })
     }
 }
 

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -1,6 +1,6 @@
 use crate::smith_waterman::score_fits_in_u8;
 use crate::sort::radix_sort_matches;
-use crate::{Config, Match, MatchIndices};
+use crate::{Config, Match, MatchIndices, Matching};
 
 #[cfg(target_arch = "aarch64")]
 use crate::literal::LiteralNEON;
@@ -89,6 +89,55 @@ impl Matcher {
             config: config.clone(),
             needs_unicode: config.unicode.respects_unicode_for(needle),
         }
+    }
+
+    /// Creates a matcher from a given query string, where special syntax changes
+    /// the matching mode
+    ///
+    /// `foo` - Matching::Fuzzy
+    /// `^foo` - Matching::Prefix
+    /// `foo$` - Matching::Suffix
+    /// `'foo` - Matching::Substring
+    /// `^foo$` - Matching::Exact
+    ///
+    /// Any special character can be escaped with a backslash, e.g. `\^foo`,
+    /// `foo\$` or `\'foo` match the literal leading/trailing character.
+    pub fn from_query(query: &str) -> Self {
+        let mut needle = query;
+        let mut prefix = false;
+        let mut suffix = false;
+        let mut substring = false;
+
+        // Leading
+        if let Some(rest) = needle.strip_prefix('^') {
+            needle = rest;
+            prefix = true;
+        } else if let Some(rest) = needle.strip_prefix('\'') {
+            needle = rest;
+            substring = true;
+        } else if needle.starts_with("\\^") || needle.starts_with("\\'") {
+            needle = &needle[1..]; // drop the backslash, keep the literal char
+        }
+
+        // Trailing
+        let needle = if let Some(head) = needle.strip_suffix("\\$") {
+            format!("{head}$") // drop the backslash, keep the literal `$`
+        } else if let Some(head) = needle.strip_suffix('$') {
+            suffix = true;
+            head.to_string()
+        } else {
+            needle.to_string()
+        };
+
+        let mode = match (prefix, suffix, substring) {
+            (true, true, _) => Matching::Exact,
+            (true, false, _) => Matching::Prefix,
+            (false, true, _) => Matching::Suffix,
+            (false, false, true) => Matching::Substring,
+            _ => Matching::Fuzzy,
+        };
+
+        Self::new(&needle, &Config::default().matching(mode))
     }
 
     pub fn config(&self) -> &Config {
@@ -386,6 +435,28 @@ impl Matcher {
 mod tests {
     use super::*;
     use crate::{CaseMatching, match_list};
+
+    fn assert_from_query(query: &str, needle: &str, matching: Matching) {
+        let matcher = Matcher::from_query(query);
+        assert_eq!(matcher.needle(), needle);
+        assert_eq!(matcher.config().matching, matching);
+    }
+
+    #[test]
+    fn from_query_selects_matching_mode() {
+        assert_from_query("foo", "foo", Matching::Fuzzy);
+        assert_from_query("^foo", "foo", Matching::Prefix);
+        assert_from_query("foo$", "foo", Matching::Suffix);
+        assert_from_query("'foo", "foo", Matching::Substring);
+        assert_from_query("^foo$", "foo", Matching::Exact);
+    }
+
+    #[test]
+    fn from_query_escapes_special_syntax() {
+        assert_from_query("\\^foo", "^foo", Matching::Fuzzy);
+        assert_from_query("foo\\$", "foo$", Matching::Fuzzy);
+        assert_from_query("\\'foo", "'foo", Matching::Fuzzy);
+    }
 
     #[test]
     fn test_basic() {

--- a/src/matcher/parallel.rs
+++ b/src/matcher/parallel.rs
@@ -113,10 +113,7 @@ mod tests {
             haystacks[index] = value.to_string();
         }
 
-        let config = Config {
-            sort: true,
-            ..Config::default()
-        };
+        let config = Config::default().sort(true);
         let sequential = match_list("abc", &haystacks, &config);
         assert!(sequential.is_sorted());
 

--- a/src/prefilter/backend/mod.rs
+++ b/src/prefilter/backend/mod.rs
@@ -15,6 +15,18 @@ mod sse;
 #[cfg(target_arch = "x86_64")]
 pub use avx::PrefilterAVX;
 
+// Low-level SIMD backends re-exported so other modules (e.g. the literal matcher) can build on
+// the raw byte-search primitives (`splat`/`occ`/`load`) directly.
+#[cfg(target_arch = "x86_64")]
+pub(crate) use avx::PrefilterAVXBackend;
+#[cfg(target_arch = "x86_64")]
+pub(crate) use avx512::PrefilterAVX512Backend;
+#[cfg(target_arch = "aarch64")]
+pub(crate) use neon::PrefilterNEONBackend;
+pub(crate) use scalar::PrefilterScalarBackend;
+#[cfg(target_arch = "x86_64")]
+pub(crate) use sse::PrefilterSSEBackend;
+
 #[cfg(target_arch = "x86_64")]
 pub type PrefilterAVX512 = Prefilter<avx512::PrefilterAVX512Backend>;
 #[cfg(target_arch = "aarch64")]

--- a/tests/api_properties.rs
+++ b/tests/api_properties.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use frizbee::{
-    CaseMatching, Config, Match, MatchIndices, Matcher, Scoring, match_list, match_list_indices,
-    match_list_parallel,
+    CaseMatching, Config, Match, MatchIndices, Matcher, Matching, Scoring, match_list,
+    match_list_indices, match_list_parallel,
 };
 
 // Did you know you could do this?? News to me
@@ -42,6 +42,13 @@ impl ApiCase {
             1 => CaseMatching::Smart,
             _ => CaseMatching::Respect,
         };
+        let matching = match cursor.next() % 5 {
+            0 => Matching::Fuzzy,
+            1 => Matching::Exact,
+            2 => Matching::Prefix,
+            3 => Matching::Suffix,
+            _ => Matching::Substring,
+        };
 
         Self {
             needle: cursor.string(needle_len),
@@ -49,6 +56,7 @@ impl ApiCase {
             config: Config {
                 max_typos,
                 casing,
+                matching,
                 sort: cursor.bool(),
                 ..Config::default()
             },
@@ -143,7 +151,7 @@ fn assert_indices_contract(case: &ApiCase, matches: &[Match], indices: &[MatchIn
         }
     }
 
-    if case.config.max_typos.is_none() {
+    if case.config.max_typos.is_none() || case.config.matching != Matching::Fuzzy {
         assert_eq!(
             indices_set, match_set,
             "indices and matches should agree exactly without typo filtering for {case:?}"

--- a/tests/api_properties.rs
+++ b/tests/api_properties.rs
@@ -53,13 +53,11 @@ impl ApiCase {
         Self {
             needle: cursor.string(needle_len),
             haystacks,
-            config: Config {
-                max_typos,
-                casing,
-                matching,
-                sort: cursor.bool(),
-                ..Config::default()
-            },
+            config: Config::default()
+                .max_typos(max_typos)
+                .casing(casing)
+                .matching(matching)
+                .sort(cursor.bool()),
         }
     }
 }
@@ -266,11 +264,7 @@ fn unicode_matcher_zero_typo_uses_byte_offsets_and_exact_flags() {
         "nomatch".to_string(),
         "x".repeat(65),
     ];
-    let config = Config {
-        max_typos: Some(0),
-        sort: false,
-        ..Config::default()
-    };
+    let config = Config::default().max_typos(Some(0)).sort(false);
 
     let matches = match_list("إن", &haystacks, &config);
     let mut matcher = Matcher::new("إن", &config);
@@ -297,11 +291,7 @@ fn unicode_matcher_zero_typo_uses_byte_offsets_and_exact_flags() {
 
 #[test]
 fn unicode_matcher_indices_cover_gaps_and_chunk_boundaries() {
-    let config = Config {
-        max_typos: None,
-        sort: false,
-        ..Config::default()
-    };
+    let config = Config::default().max_typos(None).sort(false);
 
     let gap_haystacks = ["é😀x"];
     let gap_matches = match_list("éx", &gap_haystacks, &config);
@@ -327,20 +317,12 @@ fn unicode_matcher_indices_cover_gaps_and_chunk_boundaries() {
 #[test]
 fn unicode_matcher_typo_prefilter_counts_scalar_values() {
     let haystacks = ["ن", "😀", "x"];
-    let config = Config {
-        max_typos: Some(1),
-        sort: false,
-        ..Config::default()
-    };
+    let config = Config::default().max_typos(Some(1)).sort(false);
 
     let matches = match_list("إن", &haystacks, &config);
     assert_eq!(match_indices(&matches), vec![0]);
 
-    let many_typo_config = Config {
-        max_typos: Some(2),
-        sort: false,
-        ..Config::default()
-    };
+    let many_typo_config = Config::default().max_typos(Some(2)).sort(false);
     let matches = match_list("éन😀", &haystacks, &many_typo_config);
     assert_eq!(match_indices(&matches), vec![1]);
 }
@@ -348,20 +330,13 @@ fn unicode_matcher_typo_prefilter_counts_scalar_values() {
 #[test]
 fn case_matching_modes_apply_to_matches_and_indices() {
     let haystacks = ["foo", "FOO", "fOo", "xxfooxx"];
-    let config = Config {
-        sort: false,
-        ..Config::default()
-    };
+    let config = Config::default().sort(false);
     assert_eq!(
         match_indices(&match_list("foo", &haystacks, &config)),
         vec![0, 1, 2, 3]
     );
 
-    let config = Config {
-        casing: CaseMatching::Respect,
-        sort: false,
-        ..Config::default()
-    };
+    let config = Config::default().casing(CaseMatching::Respect).sort(false);
     assert_eq!(
         match_indices(&match_list("foo", &haystacks, &config)),
         vec![0, 3]
@@ -374,11 +349,7 @@ fn case_matching_modes_apply_to_matches_and_indices() {
         vec![0, 3]
     );
 
-    let config = Config {
-        casing: CaseMatching::Smart,
-        sort: false,
-        ..Config::default()
-    };
+    let config = Config::default().casing(CaseMatching::Smart).sort(false);
     assert_eq!(
         match_indices(&match_list(
             "FoO",
@@ -421,10 +392,7 @@ fn parallel_chunk_boundaries_match_sequential() {
         ],
     );
 
-    let sorted = Config {
-        sort: true,
-        ..Config::default()
-    };
+    let sorted = Config::default().sort(true);
     let sequential = match_list("abc", &haystacks, &sorted);
     let parallel_one = match_list_parallel("abc", &haystacks, &sorted, 1);
     assert_match_views_eq("single-thread chunk boundary", &parallel_one, &sequential);
@@ -432,10 +400,7 @@ fn parallel_chunk_boundaries_match_sequential() {
     let parallel = match_list_parallel("abc", &haystacks, &sorted, 8);
     assert_match_views_eq("sorted chunk boundary", &parallel, &sequential);
 
-    let unsorted = Config {
-        sort: false,
-        ..Config::default()
-    };
+    let unsorted = Config::default().sort(false);
     let sequential = match_list("abc", &haystacks, &unsorted);
     let parallel = match_list_parallel("abc", &haystacks, &unsorted, 8);
     assert_eq!(
@@ -448,10 +413,7 @@ fn parallel_chunk_boundaries_match_sequential() {
 fn sorted_parallel_equal_scores_use_index_tiebreaking_across_chunks() {
     let haystacks = haystacks_with(4097, &[(2047, "abc"), (2048, "abc"), (4096, "abc")]);
 
-    let config = Config {
-        sort: true,
-        ..Config::default()
-    };
+    let config = Config::default().sort(true);
     let sequential = match_list("abc", &haystacks, &config);
     assert_eq!(match_indices(&sequential), vec![2047, 2048, 4096]);
 
@@ -462,10 +424,7 @@ fn sorted_parallel_equal_scores_use_index_tiebreaking_across_chunks() {
 #[test]
 fn public_indices_are_reverse_byte_offsets() {
     let haystacks = ["xabcx", "a_b_c", "nomatch"];
-    let config = Config {
-        sort: false,
-        ..Config::default()
-    };
+    let config = Config::default().sort(false);
 
     let matches = match_list_indices("abc", &haystacks, &config);
     assert_eq!(matches.len(), 2);
@@ -478,11 +437,7 @@ fn public_indices_are_reverse_byte_offsets() {
 #[test]
 #[cfg(feature = "match_end_col")]
 fn match_end_col_survives_prefilter_offsets() {
-    let config = Config {
-        max_typos: None,
-        sort: false,
-        ..Config::default()
-    };
+    let config = Config::default().max_typos(None).sort(false);
     let matches = match_list("abc", &["xabcx", "abcdef", "xxabc"], &config);
     assert_eq!(matches.len(), 3);
     assert_eq!(matches[0].end_col, 3);
@@ -492,14 +447,11 @@ fn match_end_col_survives_prefilter_offsets() {
 
 #[test]
 fn custom_scoring_stays_within_overflow_guard() {
-    let config = Config {
-        scoring: Scoring {
-            match_score: 8,
-            matching_case_bonus: 1,
-            ..Scoring::default()
-        },
-        ..Config::default()
-    };
+    let config = Config::default().scoring(Scoring {
+        match_score: 8,
+        matching_case_bonus: 1,
+        ..Scoring::default()
+    });
     let matches = match_list("abc", &["abc", "a_b_c"], &config);
     assert_eq!(matches.len(), 2);
 }


### PR DESCRIPTION
Closes #18

We should also provide a `Matcher::from_query(query)` API that automatically parses `'foo`, `^foo`, `foo$` and `^foo$` syntax