### PR TITLE
chore: explicitly list `rust-version` as v1.89.0 (and check it in CI)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,23 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+  msrv:
+    runs-on: ubuntu-latest
+    name: MSRV (${{ matrix.msrv }})
+
+    strategy:
+      matrix:
+        msrv: ["1.89.0"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ${{ matrix.msrv }}
+        run: rustup toolchain install ${{ matrix.msrv }}
+
+      - name: cargo +${{ matrix.msrv }} check
+        run: cargo +${{ matrix.msrv }} check --all-targets --all-features
+
   clippy:
     runs-on: ubuntu-latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 repository = "https://github.com/saghen/frizbee"
 keywords = ["fuzzy-search", "fuzzy-matching", "string-matching", "simd", "smith-waterman"]
 categories = ["algorithms", "text-processing"]
+rust-version = "1.89.0" # Changing this? Remember to update CI to test the new msrv!
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Closes https://github.com/saghen/frizbee/issues/87

Sets msrv as 1.89.0 and runs `cargo check` in CI.